### PR TITLE
Add file logging out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ php vendor/bin/ppq list
 
 Lists all the queues that you defined in your config and their currently running and waiting jobs.
 
+#### Get Logs of a Job
+
+```bash
+php vendor/bin/ppq logs 1a2b3c.456def
+```
+
+By default, the `logs` command prints at max the last 1000 logged lines. If you want to get more or less, you can use the `--lines` option:
+
+```bash
+php vendor/bin/ppq logs 1a2b3c.456def --lines=1500
+```
+
+Or if you just want to get all logs for the job:
+
+```bash
+php vendor/bin/ppq logs 1a2b3c.456def --lines=all
+```
+
 #### Cancel a Waiting or Running Job by its ID
 
 ```bash

--- a/src/Argv.php
+++ b/src/Argv.php
@@ -64,6 +64,16 @@ class Argv
         return isset($this->argv[1]) && $this->argv[1] === 'list';
     }
 
+    public function logs(): bool
+    {
+        return isset($this->argv[1]) && $this->argv[1] === 'logs';
+    }
+
+    public function lines(): ?string
+    {
+        return $this->getArgValueByKey('lines');
+    }
+
     public function jobId(): ?string
     {
         return $this->argv[2] ?? null;
@@ -71,10 +81,15 @@ class Argv
 
     public function configPath(): ?string
     {
-        $lastArg = end($this->argv);
+        return $this->getArgValueByKey('config');
+    }
 
-        if (!empty($lastArg) && str_starts_with($lastArg, '--c=')) {
-            return substr($lastArg, 4);
+    protected function getArgValueByKey(string $key): ?string
+    {
+        foreach ($this->argv as $arg) {
+            if (!empty($arg) && str_starts_with($arg, '--' . $key . '=')) {
+                return substr($arg, strlen($key) + 3);
+            }
         }
 
         return null;

--- a/src/Exceptions/MissingDataPathException.php
+++ b/src/Exceptions/MissingDataPathException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Otsch\Ppq\Exceptions;
+
+use Exception;
+
+class MissingDataPathException extends Exception
+{
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -33,6 +33,10 @@ class Kernel
 
     public static function ppqCommand(string $command, ?string $logPath = null): SymfonyProcess
     {
+        if ($logPath) {
+            touch($logPath);
+        }
+
         $command = 'php ' . self::ppqPath() . ' ' . $command . ' --config=' . Config::getPath();
 
         if ($logPath) {

--- a/src/Logs.php
+++ b/src/Logs.php
@@ -36,9 +36,7 @@ class Logs
 
     public static function logPath(): string
     {
-        $dataPath = self::dataPath();
-
-        $logPath = $dataPath . (!str_ends_with($dataPath, '/') ? '/' : '') . 'logs';
+        $logPath = Ppq::dataPath() . 'logs';
 
         if (!file_exists($logPath)) {
             mkdir($logPath);
@@ -65,16 +63,11 @@ class Logs
 
     public static function forget(QueueRecord $queueRecord): void
     {
-        $path = self::queueLogPath($queueRecord->queue) . '/' . $queueRecord->id;
+        $path = self::queueLogPath($queueRecord->queue) . '/' . $queueRecord->id . '.log';
 
         if (file_exists($path)) {
             unlink($path);
         }
-    }
-
-    protected static function dataPath(): string
-    {
-        return Config::get('datapath');
     }
 
     /**

--- a/src/Logs.php
+++ b/src/Logs.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Otsch\Ppq;
+
+use Exception;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class Logs
+{
+    /**
+     * @throws Exception
+     */
+    public static function getJobLog(QueueRecord $queueRecord, ?int $numberOfLines = 1000): string
+    {
+        $jobLogFilePath = self::queueJobLogPath($queueRecord);
+
+        if (!$numberOfLines) {
+            $fileContent = file_get_contents($jobLogFilePath);
+
+            return $fileContent === false ? '' : $fileContent;
+        }
+
+        return implode('', self::getLastXLinesOfFile($jobLogFilePath, $numberOfLines));
+    }
+
+    /**
+     * @param QueueRecord $queueRecord
+     * @param int|null $numberOfLines
+     * @return void
+     * @throws Exception
+     */
+    public static function printJobLog(QueueRecord $queueRecord, ?int $numberOfLines = 1000): void
+    {
+        echo self::getJobLog($queueRecord, $numberOfLines);
+    }
+
+    public static function logPath(): string
+    {
+        $dataPath = self::dataPath();
+
+        $logPath = $dataPath . (!str_ends_with($dataPath, '/') ? '/' : '') . 'logs';
+
+        if (!file_exists($logPath)) {
+            mkdir($logPath);
+        }
+
+        return $logPath;
+    }
+
+    public static function queueLogPath(string $queue): string
+    {
+        $path = self::logPath() . '/' . $queue;
+
+        if (!file_exists($path)) {
+            mkdir($path);
+        }
+
+        return $path;
+    }
+
+    public static function queueJobLogPath(QueueRecord $queueRecord): string
+    {
+        return self::queueLogPath($queueRecord->queue) . '/' . $queueRecord->id . '.log';
+    }
+
+    public static function forget(QueueRecord $queueRecord): void
+    {
+        $path = self::queueLogPath($queueRecord->queue) . '/' . $queueRecord->id;
+
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
+    protected static function dataPath(): string
+    {
+        return Config::get('datapath');
+    }
+
+    /**
+     * @return string[]
+     * @throws Exception
+     */
+    protected static function getLastXLinesOfFile(string $path, int $numberOfLines): array
+    {
+        $handle = fopen($path, "r");
+
+        if (!$handle) {
+            throw new Exception("Can't open log file.");
+        }
+
+        $lines = [];
+
+        while (!feof($handle)) {
+            $line = fgets($handle);
+
+            if (is_string($line)) {
+                $lines[] = $line;
+            }
+
+            if (count($lines) > $numberOfLines) {
+                array_shift($lines);
+            }
+        }
+
+        fclose($handle);
+
+        return $lines;
+    }
+}

--- a/src/Ppq.php
+++ b/src/Ppq.php
@@ -4,6 +4,7 @@ namespace Otsch\Ppq;
 
 use Otsch\Ppq\Entities\QueueRecord;
 use Otsch\Ppq\Entities\Values\QueueJobStatus;
+use Otsch\Ppq\Exceptions\MissingDataPathException;
 
 class Ppq
 {
@@ -112,6 +113,17 @@ class Ppq
         ?int $pid = null,
     ): array {
         return Config::getDriver()->where($queue, $jobClassName, $status, $args, $pid);
+    }
+
+    public static function dataPath(string $pathWithinDataPath = ''): string
+    {
+        $path = Config::get('datapath');
+
+        if (!$path) {
+            throw new MissingDataPathException('No datapath defined in config.');
+        }
+
+        return $path . (!str_ends_with($path, '/') ? '/' : '') . $pathWithinDataPath;
     }
 
     /**

--- a/src/PpqJob.php
+++ b/src/PpqJob.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Otsch\Ppq;
+
+use Otsch\Ppq\Contracts\QueueableJob;
+use Otsch\Ppq\Loggers\EchoLogger;
+use Psr\Log\LoggerInterface;
+
+abstract class PpqJob implements QueueableJob
+{
+    public function __construct(protected LoggerInterface $logger = new EchoLogger())
+    {
+    }
+}

--- a/src/Process.php
+++ b/src/Process.php
@@ -94,12 +94,14 @@ class Process
     public function cancel(): void
     {
         if ($this->process->isRunning()) {
-            $this->process->stop();
+            $exitCode = $this->process->stop(0);
 
             $this->logger->warning(
                 'Cancelled running job ' . $this->queueRecord->id . ' (class ' . $this->queueRecord->jobClass .
                 ', args ' . ListCommand::argsToString($this->queueRecord->args) . ')'
             );
+
+            var_dump('exit code: ' . $exitCode);
 
             $this->reloadQueueRecord();
 

--- a/src/Process.php
+++ b/src/Process.php
@@ -69,15 +69,15 @@ class Process
     {
         $pid = $this->process->getPid();
 
-        if ($pid) {
-            $command = Processes::getCommandByPid($pid);
-        }
+//        if ($pid) {
+//            $command = Processes::getCommandByPid($pid);
+//        }
 
         /** @var int $pid */
 
         $this->process->stop(0);
 
-        if (!empty($command)) {
+        /*if (!empty($command)) {
             $this->tryToFindAndKillZombieSubProcesses($pid, $command);
         }
 
@@ -99,7 +99,12 @@ class Process
                 'Cancelled running job ' . $this->queueRecord->id . ' (class ' . $this->queueRecord->jobClass .
                 ', args ' . ListCommand::argsToString($this->queueRecord->args) . ')'
             );
-        }
+        }*/
+
+        $this->logger->warning(
+            'Cancelled running job ' . $this->queueRecord->id . ' (class ' . $this->queueRecord->jobClass .
+            ', args ' . ListCommand::argsToString($this->queueRecord->args) . ')'
+        );
 
         $this->reloadQueueRecord();
 

--- a/src/Process.php
+++ b/src/Process.php
@@ -101,6 +101,8 @@ class Process
                 ', args ' . ListCommand::argsToString($this->queueRecord->args) . ')'
             );
 
+            var_dump($this->process->isRunning());
+            var_dump($this->process->isTerminated());
             var_dump('exit code: ' . $exitCode);
 
             $this->reloadQueueRecord();

--- a/src/Process.php
+++ b/src/Process.php
@@ -75,6 +75,8 @@ class Process
                     !self::isOwnPidOrOneOffDuplicate($pid, $outputLine, $strings, $ownPid, $processOutput)
                 ) {
                     var_dump('found running process');
+                    var_dump($pid);
+                    var_dump($ownPid);
                     var_dump($outputLine);
 
                     return true;

--- a/src/Process.php
+++ b/src/Process.php
@@ -74,6 +74,9 @@ class Process
                     self::stringContainsStrings($outputLine, $strings) &&
                     !self::isOwnPidOrOneOffDuplicate($pid, $outputLine, $strings, $ownPid, $processOutput)
                 ) {
+                    var_dump('found running process');
+                    var_dump($outputLine);
+
                     return true;
                 }
             }

--- a/src/Process.php
+++ b/src/Process.php
@@ -2,6 +2,7 @@
 
 namespace Otsch\Ppq;
 
+use Exception;
 use Otsch\Ppq\Entities\QueueRecord;
 use Otsch\Ppq\Entities\Values\QueueJobStatus;
 use Otsch\Ppq\Loggers\EchoLogger;
@@ -17,110 +18,16 @@ class Process
     ) {
     }
 
-    public static function runningPhpProcessWithPidExists(int $pid): bool
-    {
-        $ownPid = getmypid();
-
-        if ($ownPid === $pid) {
-            return true;
-        }
-
-        $process = self::runCommand('ps ax | grep php');
-
-        if ($process->isSuccessful()) {
-            foreach (explode(PHP_EOL, $process->getOutput()) as $outputLine) {
-                $outputLine = trim($outputLine);
-
-                $splitAtSpace = explode(' ', trim($outputLine), 2);
-
-                if (is_numeric($splitAtSpace[0]) && (int) $splitAtSpace[0] === $pid) {
-                    return true;
-                }
-            }
-        }
-
-        if (!$process->isSuccessful() || str_contains($process->getOutput(), 'ps: command not found')) {
-            return self::runningPhpProcessWithPidExistsWherePsCommandNotAvailable($pid);
-        }
-
-        return false;
-    }
-
     /**
-     * @param string|string[] $strings
-     * @return bool
+     * @throws Exception
+     * @throws Exceptions\InvalidQueueDriverException
      */
-    public static function runningPhpProcessContainingStringsExists(string|array $strings): bool
-    {
-        $ownPid = getmypid();
-
-        if ($ownPid === false) {
-            return false;
-        }
-
-        $process = self::runCommand('ps ax | grep php');
-
-        if ($process->isSuccessful() && self::processOutputContainsStrings($process, $strings)) {
-            $processOutput = $process->getOutput();
-
-            foreach (explode(PHP_EOL, $processOutput) as $outputLine) {
-                $pid = self::getPidFromPsCommandOutputLine($outputLine);
-
-                if (!$pid || $pid === $ownPid) {
-                    continue;
-                }
-
-                if (
-                    self::stringContainsStrings($outputLine, $strings) &&
-                    !self::isOwnPidOrOneOffDuplicate($pid, $outputLine, $strings, $ownPid, $processOutput)
-                ) {
-                    var_dump('found running process');
-                    var_dump($pid);
-                    var_dump($ownPid);
-                    var_dump($outputLine);
-
-                    return true;
-                }
-            }
-        }
-
-        if (!$process->isSuccessful() || str_contains($process->getOutput(), 'ps: command not found')) {
-            return self::runningPhpProcessContainingStringsExistsWherePsCommandNotAvailable($strings, $ownPid);
-        }
-
-        return false;
-    }
-
     public function cancel(): void
     {
         if ($this->process->isRunning()) {
-            $pid = $this->process->getPid();
-
-            $exitCode = $this->process->stop(0);
-
-            $this->logger->warning(
-                'Cancelled running job ' . $this->queueRecord->id . ' (class ' . $this->queueRecord->jobClass .
-                ', args ' . ListCommand::argsToString($this->queueRecord->args) . ')'
-            );
-
-            var_dump($this->process->isRunning());
-            var_dump($this->process->isTerminated());
-            var_dump('exit code: ' . $exitCode);
-            if (is_int($pid)) {
-                var_dump(Process::runningPhpProcessWithPidExists($pid));
-            }
-
-            $this->reloadQueueRecord();
-
-            $this->queueRecord->status = QueueJobStatus::cancelled;
+            $this->cancelRunningProcess();
         } else {
-            $this->logger->info(
-                'Job ' . $this->queueRecord->id . ' should have been cancelled, but it looks like it already finished.'
-            );
-
-            $this->reloadQueueRecord();
-
-            $this->queueRecord->status = QueueJobStatus::finished;
+            $this->cancelFinishedProcess();
         }
 
         $this->queueRecord->pid = null;
@@ -130,10 +37,6 @@ class Process
 
     public function finish(): void
     {
-        if ($this->process->isRunning()) {
-            $this->process->stop();
-        }
-
         $this->reloadQueueRecord();
 
         if ($this->process->isSuccessful()) {
@@ -159,171 +62,91 @@ class Process
         }
     }
 
-    protected static function runCommand(string $command): SymfonyProcess
-    {
-        $process = SymfonyProcess::fromShellCommandline($command);
-
-        $process->run();
-
-        return $process;
-    }
-
     /**
-     * @param string|string[] $strings
+     * @throws Exception
      */
-    protected static function processOutputContainsStrings(SymfonyProcess $process, string|array $strings): bool
+    protected function cancelRunningProcess(): void
     {
-        return self::stringContainsStrings($process->getOutput(), $strings);
-    }
+        $pid = $this->process->getPid();
 
-    /**
-     * @param string|string[] $strings
-     */
-    protected static function stringContainsStrings(string $string, string|array $strings): bool
-    {
-        if (is_string($strings)) {
-            return str_contains($string, $strings);
+        if ($pid) {
+            $command = Processes::getCommandByPid($pid);
         }
 
-        foreach ($strings as $stringsString) {
-            if (!str_contains($string, $stringsString)) {
-                return false;
+        /** @var int $pid */
+
+        $this->process->stop(0);
+
+        if (!empty($command)) {
+            $this->tryToFindAndKillZombieSubProcesses($pid, $command);
+        }
+
+        $pidIsGone = Utils::tryUntil(function () use ($pid) {
+            return Processes::pidStillExists($pid) === false;
+        });
+
+        if (!$pidIsGone) {
+            if (!Processes::kill($pid)) {
+                $this->logger->warning(
+                    'Killed running job ' . $this->queueRecord->id . ' (class ' . $this->queueRecord->jobClass .
+                    ', args ' . ListCommand::argsToString($this->queueRecord->args) . ')'
+                );
+            } else {
+                throw new Exception('Failed to cancel process.');
             }
+        } else {
+            $this->logger->warning(
+                'Cancelled running job ' . $this->queueRecord->id . ' (class ' . $this->queueRecord->jobClass .
+                ', args ' . ListCommand::argsToString($this->queueRecord->args) . ')'
+            );
         }
 
-        return true;
-    }
+        $this->reloadQueueRecord();
 
-    protected static function runningPhpProcessWithPidExistsWherePsCommandNotAvailable(int $pid): bool
-    {
-        $process = self::runCommand('cat /proc/' . $pid . '/cmdline');
-
-        return $process->isSuccessful() &&
-            !empty($process->getOutput()) &&
-            !self::processOutputContainsStrings($process, 'No such file');
+        $this->queueRecord->status = QueueJobStatus::cancelled;
     }
 
     /**
-     * @param string|string[] $strings
+     * @throws Exception
      */
-    protected static function runningPhpProcessContainingStringsExistsWherePsCommandNotAvailable(
-        string|array $strings,
-        int $ownPid,
-    ): bool {
-        $process = self::runCommand('cd /proc && ls');
+    protected function cancelFinishedProcess(): void
+    {
+        $pid = $this->queueRecord->pid;
 
-        if ($process->isSuccessful()) {
-            foreach (explode(PHP_EOL, $process->getOutput()) as $pid) {
-                if (!is_numeric(trim($pid))) {
-                    continue;
+        if ($pid && Processes::pidStillExists($pid)) {
+            $this->tryToFindAndKillZombieSubProcesses($pid);
+
+            $this->process->stop(0);
+
+            if (Processes::pidStillExists($pid)) {
+                if (Processes::kill($pid)) {
+                    $this->logger->warning('Killed job ' . $this->queueRecord->id);
+                } else {
+                    $this->logger->error('Killing job ' . $this->queueRecord->id . ' failed');
+
+                    throw new Exception('Killing job failed.');
                 }
-
-                $pid = (int) trim($pid);
-
-                if (self::isOwnPidOrOneOffDuplicateWherePsCommandNotAvailable($pid, $strings, $ownPid)) {
-                    continue;
-                }
-
-                $process = self::runCommand('cat /proc/' . $pid . '/cmdline');
-
-                if ($process->isSuccessful() && self::processOutputContainsStrings($process, $strings)) {
-                    return true;
-                }
+            } else {
+                $this->logger->warning('Stopped job ' . $this->queueRecord->id);
             }
+        } else {
+            $this->logger->info(
+                'Job ' . $this->queueRecord->id . ' should have been cancelled, but it looks like it already finished.'
+            );
         }
 
-        return false;
+        $this->reloadQueueRecord();
+
+        $this->queueRecord->status = QueueJobStatus::finished;
     }
 
-    /**
-     * I noticed that the list of running processes often contains a duplicate of a process/command with a pid that is
-     * one off (-1/+1). When checking for a certain running process we want to exclude the current process we're in.
-     * So if a found process's pid is one of the pid of the current PHP process and both (current and one off) match
-     * the search request, exclude that process.
-     *
-     * @param string|string[] $strings
-     */
-    protected static function isOwnPidOrOneOffDuplicate(
-        int $pid,
-        string $outputLine,
-        string|array $strings,
-        int $ownPid,
-        string $psCommandOutput,
-    ): bool {
-        if ($pid === $ownPid) {
-            return true;
-        }
-
-        if ($pid === $ownPid - 1 || $pid === $ownPid + 1) {
-            if (self::stringContainsStrings($outputLine, $strings) && str_starts_with($outputLine, 'sh -c ')) {
-                $ownProcess = self::findOwnProcessInPsCommandOutput($psCommandOutput, $ownPid);
-
-                if (!$ownProcess) {
-                    // Can't find command of own process, but it's very likely that the process in question is a
-                    // duplicate. Returning false here can have worse consequences than falsely returning true.
-                    return true;
-                }
-
-                return self::stringContainsStrings($ownProcess, $strings);
-            }
-        }
-
-        return false;
-    }
-
-    protected static function findOwnProcessInPsCommandOutput(string $psCommandOutput, int $ownPid): ?string
+    protected function tryToFindAndKillZombieSubProcesses(int $pid, ?string $command = null): void
     {
-        foreach (explode(PHP_EOL, $psCommandOutput) as $outputLine) {
-            $pid = self::getPidFromPsCommandOutputLine($outputLine);
+        $zombieSubProcess = Processes::findRunningSubProcess($pid, $command);
 
-            if ($pid === $ownPid) {
-                return $outputLine;
-            }
+        if ($zombieSubProcess && is_int($zombieSubProcess['pid'])) {
+            Processes::kill($zombieSubProcess['pid']);
         }
-
-        return null;
-    }
-
-    /**
-     * Same as isOwnPidOrOneOffDuplicate() for environments where ps command is not available.
-     *
-     * @param string|string[] $strings
-     */
-    protected static function isOwnPidOrOneOffDuplicateWherePsCommandNotAvailable(
-        int $pid,
-        string|array $strings,
-        int $ownPid = null
-    ): bool {
-        if ($pid === $ownPid) {
-            return true;
-        }
-
-        if ($pid === $ownPid - 1 || $pid === $ownPid + 1) {
-            $process = self::runCommand('cat /proc/' . $ownPid . '/cmdline');
-
-            if ($process->isSuccessful() && self::processOutputContainsStrings($process, $strings)) {
-                $process = self::runCommand('cat /proc/' . $pid . '/cmdline');
-
-                return $process->isSuccessful() &&
-                    self::processOutputContainsStrings($process, $strings) &&
-                    str_starts_with($process->getOutput(), 'sh -c ');
-            }
-        }
-
-        return false;
-    }
-
-    protected static function getPidFromPsCommandOutputLine(string $line): ?int
-    {
-        $line = trim($line);
-
-        $splitAtSpace = explode(' ', $line, 2);
-
-        if (!is_numeric($splitAtSpace[0])) {
-            return null;
-        }
-
-        return (int) $splitAtSpace[0];
     }
 
     protected function reloadQueueRecord(): void

--- a/src/Process.php
+++ b/src/Process.php
@@ -94,6 +94,8 @@ class Process
     public function cancel(): void
     {
         if ($this->process->isRunning()) {
+            $pid = $this->process->getPid();
+
             $exitCode = $this->process->stop(0);
 
             $this->logger->warning(
@@ -104,6 +106,9 @@ class Process
             var_dump($this->process->isRunning());
             var_dump($this->process->isTerminated());
             var_dump('exit code: ' . $exitCode);
+            if (is_int($pid)) {
+                var_dump(Process::runningPhpProcessWithPidExists($pid));
+            }
 
             $this->reloadQueueRecord();
 

--- a/src/Process.php
+++ b/src/Process.php
@@ -255,7 +255,7 @@ class Process
         }
 
         if ($pid === $ownPid - 1 || $pid === $ownPid + 1) {
-            if (self::stringContainsStrings($outputLine, $strings)) {
+            if (self::stringContainsStrings($outputLine, $strings) && str_starts_with($outputLine, 'sh -c ')) {
                 $ownProcess = self::findOwnProcessInPsCommandOutput($psCommandOutput, $ownPid);
 
                 if (!$ownProcess) {
@@ -304,7 +304,9 @@ class Process
             if ($process->isSuccessful() && self::processOutputContainsStrings($process, $strings)) {
                 $process = self::runCommand('cat /proc/' . $pid . '/cmdline');
 
-                return $process->isSuccessful() && self::processOutputContainsStrings($process, $strings);
+                return $process->isSuccessful() &&
+                    self::processOutputContainsStrings($process, $strings) &&
+                    str_starts_with($process->getOutput(), 'sh -c ');
             }
         }
 

--- a/src/Processes.php
+++ b/src/Processes.php
@@ -195,7 +195,7 @@ class Processes
             var_dump('is zombie?');
             var_dump($command);
 
-            return str_contains($command ?? '', '<defunct>');
+            return !$command || str_contains($command, '<defunct>');
         } else {
             $statusCommand = self::runCommand('cat /proc/' . $pid . '/status');
 

--- a/src/Processes.php
+++ b/src/Processes.php
@@ -192,6 +192,9 @@ class Processes
         if (self::psCommandAvailable()) {
             $command = self::getCommandByPid($pid);
 
+            var_dump('is zombie?');
+            var_dump($command);
+
             return str_contains($command ?? '', '<defunct>');
         } else {
             $statusCommand = self::runCommand('cat /proc/' . $pid . '/status');

--- a/src/Processes.php
+++ b/src/Processes.php
@@ -174,7 +174,17 @@ class Processes
     {
         $command = self::runCommand('kill -9 ' . $pid);
 
-        return $command->isSuccessful() && self::pidStillExists($pid);
+        if (!$command->isSuccessful()) {
+            return false;
+        }
+
+        if (self::pidStillExists($pid)) {
+            Utils::tryUntil(function () use ($pid) {
+                return self::pidStillExists($pid) === false;
+            }, 10, 50000);
+        }
+
+        return self::pidStillExists($pid);
     }
 
     public static function isZombie(int $pid): bool

--- a/src/Processes.php
+++ b/src/Processes.php
@@ -200,7 +200,7 @@ class Processes
                 return true;
             }
 
-            return str_contains($statusCommand->getOutput(), 'Status:' . chr(9) . 'Z (zombie)');
+            return str_contains($statusCommand->getOutput(), 'State:' . chr(9) . 'Z (zombie)');
         }
     }
 

--- a/src/Processes.php
+++ b/src/Processes.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Otsch\Ppq;
+
+use Exception;
+
+class Processes
+{
+    protected static ?int $ownPid = null;
+
+    protected static bool $psCommandAvailable = true;
+
+    /**
+     * @var array<int, mixed[]>
+     */
+    protected static array $processMemory = [];
+
+    /**
+     * @param string[] $strings
+     * @throws Exception
+     */
+    public static function processContainingStringsExists(array $strings, bool $excludeOwn = true): bool
+    {
+        $processes = self::getProcessesContainingStrings($strings, $excludeOwn);
+
+        return !empty($processes);
+    }
+
+    /**
+     * @param string[] $strings
+     * @return array<int, string>
+     * @throws Exception
+     */
+    public static function getProcessesContainingStrings(array $strings, bool $excludeOwn = true): array
+    {
+        $filtered = [];
+
+        $allCommands = self::getAll($excludeOwn);
+
+        foreach ($allCommands as $pid => $command) {
+            foreach ($strings as $string) {
+                if (!str_contains($command, $string)) {
+                    continue 2;
+                }
+            }
+
+            $filtered[$pid] = $command;
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public static function pidStillExists(int $pid): bool
+    {
+        $all = self::getAll(false);
+
+        return isset($all[$pid]);
+    }
+
+    /**
+     * @param array<int, string>|null $allCommands
+     * @throws Exception
+     */
+    public static function getCommandByPid(int $pid, ?array $allCommands = null): ?string
+    {
+        $allCommands = $allCommands ?? self::getAll(false);
+
+        return $allCommands[$pid] ?? null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public static function getOwnPid(): int
+    {
+        if (!self::$ownPid) {
+            $pid = getmypid();
+
+            if ($pid === false) {
+                throw new Exception("Can't get pid of current process.");
+            }
+
+            self::$ownPid = $pid;
+        }
+
+        return self::$ownPid;
+    }
+
+    /**
+     * @return array<string, int|string>|null
+     * @throws Exception
+     */
+    public static function findRunningSubProcess(int $pid, ?string $command = null): ?array
+    {
+        $all = self::getAll(false);
+
+        $command = $command === null ? self::getCommandByPid($pid, $all) : $command;
+
+        if (!$command) {
+            throw new Exception('Can\'t find command for pid');
+        }
+
+        for ($i = -2; $i <= 2; $i++) {
+            if (isset($all[$pid + $i]) && self::isSubProcessOf($pid + $i, $all[$pid + $i], $pid, $command)) {
+                return ['pid' => $pid + $i, 'command' => $all[$pid + $i]];
+            }
+        }
+
+        return null;
+    }
+
+    public static function isSubProcessOf(int $pid, string $command, int $parentPid, string $parentCommand): bool
+    {
+        return $parentCommand === 'sh -c ' . $command &&
+            (
+                $pid === $parentPid - 1 ||
+                $pid === $parentPid - 2 ||
+                $pid === $parentPid + 1 ||
+                $pid === $parentPid + 2
+            );
+    }
+
+    public static function oneIsSubProcessOfTheOther(
+        int $pid,
+        string $command,
+        int $otherPid,
+        string $otherCommand
+    ): bool {
+        return self::isSubProcessOf($pid, $command, $otherPid, $otherCommand) ||
+            self::isSubProcessOf($otherPid, $otherCommand, $pid, $command);
+    }
+
+    /**
+     * @return array<int, string>
+     * @throws Exception
+     */
+    public static function getAll(bool $excludeOwn = true): array
+    {
+        $processes = self::getProcessesFromPs();
+
+        if ($processes === null) {
+            $processes = self::getProcessesFromProcDir();
+        }
+
+        if ($excludeOwn === true) {
+            $ownPid = self::getOwnPid();
+
+            $ownCommand = self::getCommandByPid($ownPid, $processes);
+
+            $processesExcludingOwn = [];
+
+            foreach ($processes as $pid => $command) {
+                if (
+                    $pid !== $ownPid &&
+                    (!is_string($ownCommand) || !self::oneIsSubProcessOfTheOther($pid, $command, $ownPid, $ownCommand))
+                ) {
+                    $processesExcludingOwn[$pid] = $command;
+                }
+            }
+
+            $processes = $processesExcludingOwn;
+        }
+
+        return $processes;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public static function kill(int $pid): bool
+    {
+        $command = self::runCommand('kill -9 ' . $pid);
+
+        return $command->isSuccessful() && self::pidStillExists($pid);
+    }
+
+    public static function runCommand(string $command): \Symfony\Component\Process\Process
+    {
+        $command = \Symfony\Component\Process\Process::fromShellCommandline($command);
+
+        $command->run();
+
+        return $command;
+    }
+
+    /**
+     * @return array<int, string>|null
+     */
+    protected static function getProcessesFromPs(): ?array
+    {
+        $psCommandOutput = self::getPsCommandOutput();
+
+        if ($psCommandOutput === null) {
+            return null;
+        }
+
+        $processes = [];
+
+        foreach (explode(PHP_EOL, $psCommandOutput) as $lineNumber => $outputLine) {
+            $splitAtSpace = explode(' ', trim($outputLine), 2);
+
+            if ($lineNumber === 0) {
+                continue;
+            }
+
+            if (count($splitAtSpace) === 2 && is_numeric($splitAtSpace[0])) {
+                $processes[(int) ($splitAtSpace[0])] = $splitAtSpace[1];
+            }
+        }
+
+        return $processes;
+    }
+
+    protected static function getPsCommandOutput(): ?string
+    {
+        if (!self::$psCommandAvailable) {
+            return null;
+        }
+
+        $command = self::runCommand('ps x -o pid,command | grep php');
+
+        if (!$command->isSuccessful() || str_contains($command->getOutput(), 'ps: command not found')) {
+            self::$psCommandAvailable = false;
+
+            return null;
+        }
+
+        return $command->getOutput();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected static function getProcessesFromProcDir(): array
+    {
+        $processes = [];
+
+        $process = self::runCommand('cd /proc && ls');
+
+        $now = time();
+
+        if ($process->isSuccessful()) {
+            foreach (explode(PHP_EOL, $process->getOutput()) as $pid) {
+                if (!is_numeric(trim($pid))) {
+                    continue;
+                }
+
+                $pid = (int) trim($pid);
+
+                if (isset(self::$processMemory[$pid])) {
+                    if ($now - self::$processMemory[$pid]['time'] < 10) {
+                        $processes[$pid] = self::$processMemory[$pid]['command'];
+
+                        continue;
+                    }
+
+                    unset(self::$processMemory[$pid]);
+                }
+
+                $process = self::runCommand('cat /proc/' . $pid . '/cmdline');
+
+                if ($process->isSuccessful()) {
+                    $command = self::replaceNullByteChar($process->getOutput());
+
+                    $processes[$pid] = $command;
+
+                    self::$processMemory[$pid] = ['time' => $now, 'command' => $command];
+                }
+            }
+        }
+
+        return $processes;
+    }
+
+    protected static function replaceNullByteChar(string $string): string
+    {
+        return str_replace("\x00", " ", $string);
+    }
+}

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -38,7 +38,7 @@ class Queue
      */
     public function startWaitingJob(QueueRecord $waitingJob): void
     {
-        $process = Kernel::ppqCommand('run ' . $waitingJob->id);
+        $process = Kernel::ppqCommand('run ' . $waitingJob->id, Logs::queueJobLogPath($waitingJob));
 
         $process->start();
 
@@ -153,5 +153,22 @@ class Queue
         }
 
         return Process::runningPhpProcessWithPidExists($queueJob->pid);
+    }
+
+    protected function initLogPath(QueueRecord $queueRecord): void
+    {
+        $dataPath = Config::get('datapath');
+
+        $logsDir = $dataPath . (!str_ends_with($dataPath, '/') ? '/' : '') . 'logs';
+
+        if (!file_exists($logsDir)) {
+            mkdir($logsDir);
+        }
+
+        $queueLogsDir = $logsDir . '/' . $queueRecord->queue;
+
+        if (!file_exists($queueLogsDir)) {
+            mkdir($queueLogsDir);
+        }
     }
 }

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -152,23 +152,6 @@ class Queue
             return false;
         }
 
-        return Process::runningPhpProcessWithPidExists($queueJob->pid);
-    }
-
-    protected function initLogPath(QueueRecord $queueRecord): void
-    {
-        $dataPath = Config::get('datapath');
-
-        $logsDir = $dataPath . (!str_ends_with($dataPath, '/') ? '/' : '') . 'logs';
-
-        if (!file_exists($logsDir)) {
-            mkdir($logsDir);
-        }
-
-        $queueLogsDir = $logsDir . '/' . $queueRecord->queue;
-
-        if (!file_exists($queueLogsDir)) {
-            mkdir($queueLogsDir);
-        }
+        return Processes::pidStillExists($queueJob->pid);
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Otsch\Ppq;
+
+use Closure;
+
+class Utils
+{
+    public static function tryUntil(
+        Closure $callback,
+        int $maxTries = 100,
+        int $sleep = 10000
+    ): mixed {
+        $tries = 0;
+
+        while (!($callbackReturnValue = $callback()) && $tries < $maxTries) {
+            usleep($sleep);
+
+            $tries++;
+        }
+
+        return $callbackReturnValue;
+    }
+}

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -30,9 +30,13 @@ class Worker
      */
     public function workQueues(): void
     {
-        if ($this->queuesAreAlreadyWorking()) {
+        if (WorkerProcess::isWorking()) {
             throw new Exception('Queues are already working');
         }
+
+        $this->logger->info('Start working queues');
+
+        WorkerProcess::set();
 
         $nextCheck = microtime(true);
 
@@ -56,6 +60,8 @@ class Worker
             $this->checkSignals();
 
             $this->checkQueues();
+
+            WorkerProcess::heartbeat();
         }
     }
 
@@ -212,10 +218,5 @@ class Worker
                 }
             }
         }
-    }
-
-    private function queuesAreAlreadyWorking(): bool
-    {
-        return Process::runningPhpProcessContainingStringsExists([Kernel::ppqPath(), 'work']);
     }
 }

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -206,6 +206,8 @@ class Worker
 
                     if ($doneCount > $queue->keepLastXPastJobs) {
                         $driver->forget($queueRecord->id);
+
+                        Logs::forget($queueRecord);
                     }
                 }
             }

--- a/src/WorkerProcess.php
+++ b/src/WorkerProcess.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Otsch\Ppq;
+
+use Exception;
+use Otsch\Ppq\Exceptions\MissingDataPathException;
+
+class WorkerProcess
+{
+    public static function isWorking(): bool
+    {
+        $data = self::get();
+
+        if ($data) {
+            if ($data['time'] && (self::getCurrentTime() - $data['time']) > 1000000) {
+                return false;
+            }
+
+            if (Processes::pidStillExists($data['pid'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws Exception
+     * @throws MissingDataPathException
+     */
+    public static function set(): void
+    {
+        if (!Ppq::dataPath()) {
+            throw new MissingDataPathException('No datapath defined in config.');
+        }
+
+        if (!file_exists(Ppq::dataPath() . 'workerprocess')) {
+            touch(Ppq::dataPath() . 'workerprocess');
+        }
+
+        $data = serialize(['pid' => Processes::getOwnPid(), 'time' => self::getCurrentTime()]);
+
+        file_put_contents(Ppq::dataPath() . 'workerprocess', $data);
+    }
+
+    public static function heartbeat(): void
+    {
+        if (!Ppq::dataPath()) {
+            throw new MissingDataPathException('No datapath defined in config.');
+        }
+
+        $fileContent = file_get_contents(Ppq::dataPath() . 'workerprocess');
+
+        if (!$fileContent) {
+            $data = [];
+        } else {
+            $data = unserialize($fileContent);
+        }
+
+        if (empty($data['pid'])) {
+            $data['pid'] = Processes::getOwnPid();
+        }
+
+        $data['time'] = self::getCurrentTime();
+
+        $newFileContent = serialize($data);
+
+        file_put_contents(Ppq::dataPath() . 'workerprocess', $newFileContent);
+    }
+
+    /**
+     * @return mixed[]|null
+     * @throws MissingDataPathException
+     */
+    public static function get(): ?array
+    {
+        if (!Ppq::dataPath()) {
+            throw new MissingDataPathException('No datapath defined in config.');
+        }
+
+        if (file_exists(Ppq::dataPath() . 'workerprocess')) {
+            $fileContent = file_get_contents(Ppq::dataPath() . 'workerprocess');
+
+            if (!empty($fileContent)) {
+                $data = @unserialize($fileContent);
+
+                if (is_array($data)) {
+                    return $data;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static function getPid(): ?int
+    {
+        return self::get()['pid'] ?? null;
+    }
+
+    public static function getTime(): ?int
+    {
+        return self::get()['time'] ?? null;
+    }
+
+    public static function unset(): void
+    {
+        if (!Ppq::dataPath()) {
+            throw new MissingDataPathException('No datapath defined in config.');
+        }
+
+        if (!file_exists(Ppq::dataPath() . 'workerprocess')) {
+            touch(Ppq::dataPath() . 'workerprocess');
+        }
+
+        file_put_contents(Ppq::dataPath() . 'workerprocess', '');
+    }
+
+    protected static function getCurrentTime(): int
+    {
+        return (int) (microtime(true) * 1000000);
+    }
+}

--- a/tests/ArgvTest.php
+++ b/tests/ArgvTest.php
@@ -85,13 +85,31 @@ test('list() returns true when the second argv array element is "list"', functio
     [true, ['vendor/bin/ppq', 'list', 'foo']],
 ]);
 
+test('logs() returns true when the second argv array element is "logs"', function (bool $expect, array $argv) {
+    expect(Argv::make($argv)->logs())->toBe($expect);
+})->with([
+    [true, ['vendor/bin/ppq', 'logs']],
+    [false, ['vendor/bin/ppq', 'foo']],
+    [false, ['vendor/bin/ppq', 'foo', 'logs']],
+    [true, ['vendor/bin/ppq', 'logs', 'foo']],
+]);
+
+test('lines() returns the argument prefixed with --lines=', function (array $argv, string $result) {
+    expect(Argv::make($argv)->lines())->toBe($result);
+})->with([
+    [['vendor/bin/ppq', 'logs', '123.asdf', '--lines=500'], '500'],
+    [['vendor/bin/ppq', 'logs', '--lines=all'], 'all'],
+    [['vendor/bin/ppq', '--lines=200', 'logs'], '200'],
+    [['vendor/bin/ppq', 'logs', 'foo', 'bar', 'baz', '--lines=300'], '300'],
+]);
+
 test('jobId() returns the third argv argument', function () {
     expect(Argv::make(['vendor/bin/ppq', 'run', '123.abc'])->jobId())->toBe('123.abc');
 });
 
 it('gets a config provided as --c argument at the end', function () {
     expect(
-        Argv::make(['vendor/bin/ppq', 'run', '123.abc', '--c=/var/www/project/src/../config/queue.php'])
+        Argv::make(['vendor/bin/ppq', 'run', '123.abc', '--config=/var/www/project/src/../config/queue.php'])
             ->configPath()
     )->toBe('/var/www/project/src/../config/queue.php');
 });

--- a/tests/KernelTest.php
+++ b/tests/KernelTest.php
@@ -35,7 +35,7 @@ it('returns a Symfony Process instance to run a ppq command containing the full 
 it('appends the set config path as --c option to the ppq command', function () {
     $process = Kernel::ppqCommand('run 123');
 
-    expect($process->getCommandLine())->toEndWith('--c=' . Config::getPath());
+    expect($process->getCommandLine())->toEndWith('--config=' . Config::getPath());
 });
 
 it('calls the bootstrap file defined in the config when run() is called', function () {

--- a/tests/LogsTest.php
+++ b/tests/LogsTest.php
@@ -21,7 +21,7 @@ beforeAll(function () {
 
     helper_tryUntil(function () {
         return count(Ppq::waiting('default')) === 0 && count(Ppq::running('default')) === 0;
-    });
+    }, sleep: 50000);
 
     WorkerProcess::stop();
 });

--- a/tests/LogsTest.php
+++ b/tests/LogsTest.php
@@ -129,4 +129,3 @@ it('creates the log dirs if they don\'t exist yet', function () {
 
     expect(file_exists($logsPath . '/' . $job->queue))->toBeTrue();
 });
-

--- a/tests/LogsTest.php
+++ b/tests/LogsTest.php
@@ -15,7 +15,7 @@ beforeAll(function () {
 
     helper_cleanUpDataPathQueueFiles();
 
-    WorkerProcess::work();
+    WorkerProcess::work('LogsTest');
 
     (new FileDriver())->add(new QueueRecord('default', LogLinesTestJob::class, id: '123abc'));
 

--- a/tests/LogsTest.php
+++ b/tests/LogsTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use Integration\WorkerProcess;
+use Otsch\Ppq\Config;
+use Otsch\Ppq\Drivers\FileDriver;
+use Otsch\Ppq\Entities\QueueRecord;
+use Otsch\Ppq\Logs;
+use Otsch\Ppq\Ppq;
+use PHPUnit\Framework\TestCase;
+use Stubs\LogLinesTestJob;
+use Stubs\LogTestJob;
+
+beforeAll(function () {
+    Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
+
+    helper_cleanUpDataPathQueueFiles();
+
+    WorkerProcess::work();
+
+    (new FileDriver())->add(new QueueRecord('default', LogLinesTestJob::class, id: '123abc'));
+
+    helper_tryUntil(function () {
+        return count(Ppq::waiting('default')) === 0 && count(Ppq::running('default')) === 0;
+    });
+
+    WorkerProcess::stop();
+});
+
+/** @var TestCase $this */
+
+it('gets a jobs log and gets the last 1000 lines by default', function () {
+    $job = new QueueRecord('default', LogTestJob::class, id: '123abc');
+
+    $logs = Logs::getJobLog($job);
+
+    $logLines = explode(PHP_EOL, $logs);
+
+    expect($logLines)->toHaveCount(1001);
+
+    expect($logLines[0])->toContain('[INFO] 2001');
+
+    expect($logLines[999])->toContain('[INFO] 3000');
+});
+
+it('gets the last x lines when you provide a value for param numberOfLines', function () {
+    $job = new QueueRecord('default', LogTestJob::class, id: '123abc');
+
+    $logs = Logs::getJobLog($job, 14);
+
+    $logLines = explode(PHP_EOL, $logs);
+
+    expect($logLines)->toHaveCount(15);
+
+    expect($logLines[0])->toContain('[INFO] 2987');
+
+    expect($logLines[13])->toContain('[INFO] 3000');
+});
+
+it('gets the whole log when you set param numberOfLines to null', function () {
+    $job = new QueueRecord('default', LogTestJob::class, id: '123abc');
+
+    $logs = Logs::getJobLog($job, null);
+
+    $logLines = explode(PHP_EOL, $logs);
+
+    expect($logLines)->toHaveCount(3001);
+
+    expect($logLines[0])->toContain('[INFO] 1');
+
+    expect($logLines[2999])->toContain('[INFO] 3000');
+});
+
+it('prints a jobs log', function () {
+    $job = new QueueRecord('default', LogTestJob::class, id: '123abc');
+
+    Logs::printJobLog($job);
+
+    $logLines = explode(PHP_EOL, $this->getActualOutput());
+
+    expect($logLines)->toHaveCount(1001);
+
+    expect($logLines[0])->toContain('[INFO] 2001');
+
+    expect($logLines[999])->toContain('[INFO] 3000');
+});
+
+it('tells you the log base path', function () {
+    expect(realpath(Logs::logPath()))->toBe(__DIR__ . '/_testdata/datapath/logs');
+});
+
+it('tells you the log path for a certain queue', function () {
+    expect(Logs::queueLogPath('other_queue'))->toBe(__DIR__ . '/_testdata/config/../datapath/logs/other_queue');
+});
+
+it('forgets the log file for a queue job', function () {
+    $job = new QueueRecord('default', LogTestJob::class, id: '123abc');
+
+    expect(file_exists(__DIR__ . '/_testdata/datapath/logs/default/' . $job->id . '.log'))->toBeTrue();
+
+    Logs::forget($job);
+});
+
+it('creates the log dirs if they don\'t exist yet', function () {
+    helper_cleanUpDataPathQueueFiles();
+
+    $logsPath = Logs::logPath();
+
+    $remainingQueueLogDirs = scandir($logsPath);
+
+    if (is_array($remainingQueueLogDirs)) {
+        foreach ($remainingQueueLogDirs as $dir) {
+            if ($dir === '.' || $dir === '..') {
+                continue;
+            }
+
+            rmdir($logsPath . '/' . $dir);
+        }
+    }
+
+    if (file_exists($logsPath)) {
+        rmdir($logsPath);
+    }
+
+    $job = new QueueRecord('default', LogTestJob::class, id: '123abc');
+
+    Logs::queueJobLogPath($job);
+
+    expect(file_exists($logsPath))->toBeTrue();
+
+    expect(file_exists($logsPath . '/' . $job->queue))->toBeTrue();
+});
+

--- a/tests/LogsTest.php
+++ b/tests/LogsTest.php
@@ -17,7 +17,7 @@ beforeAll(function () {
 
     helper_cleanUpDataPathQueueFiles();
 
-    WorkerProcess::work('LogsTest');
+    WorkerProcess::work();
 
     $job = new QueueRecord('default', LogLinesTestJob::class, id: '123abc');
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -72,7 +72,13 @@ function helper_cleanUpDataPathQueueFiles(): void
                         }
                     }
                 }
+
+                rmdir(__DIR__ . '/_testdata/datapath/logs/' . $queue);
             }
+        }
+
+        if (file_exists(__DIR__ . '/_testdata/datapath/logs')) {
+            rmdir(__DIR__ . '/_testdata/datapath/logs');
         }
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -83,19 +83,6 @@ function helper_cleanUpDataPathQueueFiles(): void
     }
 }
 
-function helper_tryUntil(Closure $callback, mixed $arg = null, int $maxTries = 100, int $sleep = 10000): mixed
-{
-    $tries = 0;
-
-    while (!($callbackReturnValue = $callback($arg)) && $tries < $maxTries) {
-        usleep($sleep);
-
-        $tries++;
-    }
-
-    return $callbackReturnValue;
-}
-
 /**
  * @param string[] $contains
  */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -56,6 +56,25 @@ function helper_cleanUpDataPathQueueFiles(): void
     if (file_exists(__DIR__ . '/_testdata/datapath/queue-infinite_waiting_jobs_queue')) {
         file_put_contents(__DIR__ . '/_testdata/datapath/queue-infinite_waiting_jobs_queue', 'a:0:{}');
     }
+
+    // clean up logs
+    if (file_exists(__DIR__ . '/_testdata/datapath/logs')) {
+        $queues = ['default', 'other_queue', 'infinite_waiting_jobs_queue'];
+
+        foreach ($queues as $queue) {
+            if (file_exists(__DIR__ . '/_testdata/datapath/logs/' . $queue)) {
+                $filesInDir = scandir(__DIR__ . '/_testdata/datapath/logs/' . $queue);
+
+                if (is_array($filesInDir)) {
+                    foreach ($filesInDir as $file) {
+                        if (str_ends_with($file, '.log')) {
+                            unlink(__DIR__ . '/_testdata/datapath/logs/' . $queue . '/' . $file);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 function helper_tryUntil(Closure $callback, mixed $arg = null, int $maxTries = 100, int $sleep = 10000): mixed

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -20,8 +20,6 @@ it('finishes a process that was successfully finished', function () {
 
     $process = Mockery::mock(\Symfony\Component\Process\Process::class);
 
-    $process->shouldReceive('isRunning')->once()->andReturn(false); // @phpstan-ignore-line
-
     $process->shouldReceive('isSuccessful')->once()->andReturn(true); // @phpstan-ignore-line
 
     $process = new Process($queueRecord, $process); // @phpstan-ignore-line
@@ -35,36 +33,6 @@ it('finishes a process that was successfully finished', function () {
     expect($this->getActualOutput())->toContain('Finished job with id');
 });
 
-it('finishes a process that is still running', function () {
-    Config::setPath(__DIR__ . '/_testdata/config/ppq.php');
-
-    $queueRecord = new QueueRecord('default', TestJob::class, QueueJobStatus::running);
-
-    $driver = Config::getDriver();
-
-    $driver->add($queueRecord);
-
-    $process = Mockery::mock(\Symfony\Component\Process\Process::class);
-
-    $process->shouldReceive('isRunning')->once()->andReturn(true); // @phpstan-ignore-line
-
-    $process->shouldReceive('stop')->once(); // @phpstan-ignore-line
-
-    $process->shouldReceive('isSuccessful')->once()->andReturn(false); // @phpstan-ignore-line
-
-    $process->shouldReceive('getErrorOutput')->twice()->andReturn('Execution was cancelled'); // @phpstan-ignore-line
-
-    $process = new Process($queueRecord, $process); // @phpstan-ignore-line
-
-    $process->finish();
-
-    expect($queueRecord->status)->toBe(QueueJobStatus::failed);
-
-    expect($queueRecord->pid)->toBeNull();
-
-    expect($this->getActualOutput())->toContain('Execution was cancelled');
-});
-
 it('finishes a process that failed', function () {
     Config::setPath(__DIR__ . '/_testdata/config/ppq.php');
 
@@ -75,8 +43,6 @@ it('finishes a process that failed', function () {
     $driver->add($queueRecord);
 
     $process = Mockery::mock(\Symfony\Component\Process\Process::class);
-
-    $process->shouldReceive('isRunning')->once()->andReturn(false); // @phpstan-ignore-line
 
     $process->shouldReceive('isSuccessful')->once()->andReturn(false); // @phpstan-ignore-line
 
@@ -93,54 +59,4 @@ it('finishes a process that failed', function () {
     expect($queueRecord->pid)->toBeNull();
 
     expect($this->getActualOutput())->toContain('There was an error');
-});
-
-it('checks if a running process with a certain pid exists', function () {
-    $process = \Symfony\Component\Process\Process::fromShellCommandline('php ' . __DIR__ . '/_testdata/counting.php');
-
-    $process->start();
-
-    $pid = $process->getPid();
-
-    expect($pid)->toBeInt()->toBeGreaterThan(0);
-
-    /** @var int $pid */
-
-    expect(Process::runningPhpProcessWithPidExists($pid))->toBeTrue();
-
-    $process->stop();
-
-    expect(Process::runningPhpProcessWithPidExists($pid))->toBeFalse();
-});
-
-it('checks if a running process containing certain strings (in command) exists', function () {
-    $process = \Symfony\Component\Process\Process::fromShellCommandline('php ' . __DIR__ . '/_testdata/counting.php');
-
-    $process->start();
-
-    $pid = $process->getPid();
-
-    expect($pid)->toBeInt()->toBeGreaterThan(0);
-
-    /** @var int $pid */
-
-    expect(Process::runningPhpProcessContainingStringsExists(['counting.php']))->toBeTrue();
-
-    $process->stop();
-
-    helper_tryUntil(function () {
-        return Process::runningPhpProcessContainingStringsExists(['counting.php']) === false;
-    }, maxTries: 10);
-
-    expect(Process::runningPhpProcessContainingStringsExists(['counting.php']))->toBeFalse();
-});
-
-test('checking if a running process containing certain strings exists, exclude the current process', function () {
-    $process = \Symfony\Component\Process\Process::fromShellCommandline(
-        'php ' . __DIR__ . '/_testdata/check-process-already-running.php'
-    );
-
-    $process->run();
-
-    expect($process->getOutput())->toBe('no');
 });

--- a/tests/ProcessesTest.php
+++ b/tests/ProcessesTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Otsch\Ppq\Processes;
+
+it('checks if a running process with a certain pid exists', function () {
+    $process = \Symfony\Component\Process\Process::fromShellCommandline(
+        'php ' . __DIR__ . '/_testdata/scripts/do-something.php'
+    );
+
+    $process->start();
+
+    $pid = $process->getPid();
+
+    expect($pid)->toBeInt()->toBeGreaterThan(0);
+
+    /** @var int $pid */
+
+    expect(Processes::pidStillExists($pid))->toBeTrue();
+
+    $process->stop(0);
+
+    expect(Processes::pidStillExists($pid))->toBeFalse();
+});
+
+it('checks if a running process containing certain strings (in command) exists', function () {
+    expect(Processes::processContainingStringsExists(['counting.php']))->toBeFalse();
+
+    $process = \Symfony\Component\Process\Process::fromShellCommandline(
+        'php ' . __DIR__ . '/_testdata/scripts/counting.php'
+    );
+
+    $process->start();
+
+    expect(Processes::processContainingStringsExists(['counting.php']))->toBeTrue();
+});
+
+test('checking if a running process containing certain strings exists, exclude the current process', function () {
+    $process = \Symfony\Component\Process\Process::fromShellCommandline(
+        'php ' . __DIR__ . '/_testdata/scripts/check-process-already-running.php'
+    );
+
+    $process->run();
+
+    expect($process->getOutput())->toBe('no');
+});
+
+it(
+    'tells if a process is a child of another process',
+    function (int $pid, string $command, int $parentPid, string $parentCommand, bool $expectedResult) {
+        expect(Processes::isSubProcessOf($pid, $command, $parentPid, $parentCommand))->toBe($expectedResult);
+    }
+)->with([
+    [123, 'php yolo.php', 121, 'sh -c php yolo.php', true],
+    [123, 'php yolo.php', 121, 'php foo.php', false],
+    [123, 'php vendor/bin/ppq list', 125, 'sh -c php vendor/bin/ppq logs 123.abc', false],
+    [123, 'php foo.php', 122, 'sh -c php foo.php', true],
+    [123, 'php foo.php', 125, 'sh -c php foo.php', true],
+    [123, 'php foo.php', 126, 'sh -c php foo.php', false],
+    [125, 'sh -c php foo.php', 123, 'php foo.php', false],
+]);
+
+it(
+    'tells if one process is parent or child of another process',
+    function (int $pid, string $command, int $otherPid, string $otherCommand, bool $expectedResult) {
+        expect(Processes::oneIsSubProcessOfTheOther($pid, $command, $otherPid, $otherCommand))->toBe($expectedResult);
+    }
+)->with([
+    [123, 'php yolo.php', 121, 'sh -c php yolo.php', true],
+    [121, 'sh -c php yolo.php', 123, 'php yolo.php', true],
+    [123, 'php yolo.php', 121, 'php foo.php', false],
+]);

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -4,8 +4,9 @@ use Otsch\Ppq\Config;
 use Otsch\Ppq\Entities\QueueRecord;
 use Otsch\Ppq\Entities\Values\QueueJobStatus;
 use Otsch\Ppq\Ppq;
-use Otsch\Ppq\Process;
+use Otsch\Ppq\Processes;
 use Otsch\Ppq\Queue;
+use Otsch\Ppq\Utils;
 use Stubs\TestJob;
 
 beforeEach(function () {
@@ -40,8 +41,8 @@ it('starts a waiting job', function () {
 
     /** @var int $pid */
 
-    helper_tryUntil(function () use ($pid) {
-        return !Process::runningPhpProcessWithPidExists($pid);
+    Utils::tryUntil(function () use ($pid) {
+        return !Processes::pidStillExists($pid);
     });
 
     expect($queue->hasAvailableSlot())->toBeTrue();
@@ -70,13 +71,13 @@ it('knows if there is a slot available for another job', function () {
 
     expect($queue->hasAvailableSlot())->toBeFalse();
 
-    helper_tryUntil(function () use ($queue) {
+    Utils::tryUntil(function () use ($queue) {
         return $queue->runningProcessesCount() < 2;
     });
 
     expect($queue->hasAvailableSlot())->toBeTrue();
 
-    helper_tryUntil(function () use ($queue) {
+    Utils::tryUntil(function () use ($queue) {
         return $queue->runningProcessesCount() === 0;
     });
 
@@ -125,7 +126,7 @@ it('tells you how many processes are currently running', function () {
     // The startWaitingJob() method is not responsible for obeying the limit.
     expect($queue->runningProcessesCount())->toBe(3);
 
-    helper_tryUntil(function () use ($queue) {
+    Utils::tryUntil(function () use ($queue) {
         return $queue->runningProcessesCount() === 0;
     });
 

--- a/tests/Stubs/LogLinesTestJob.php
+++ b/tests/Stubs/LogLinesTestJob.php
@@ -8,7 +8,7 @@ class LogLinesTestJob extends PpqJob
 {
     public function invoke(): void
     {
-        for ($i = 1; $i <= 3000; $i++) {
+        for ($i = 1; $i <= 1500; $i++) {
             $this->logger->info((string) $i);
         }
     }

--- a/tests/Stubs/LogLinesTestJob.php
+++ b/tests/Stubs/LogLinesTestJob.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Stubs;
+
+use Otsch\Ppq\PpqJob;
+
+class LogLinesTestJob extends PpqJob
+{
+    public function invoke(): void
+    {
+        for ($i = 1; $i <= 3000; $i++) {
+            $this->logger->info((string) $i);
+        }
+    }
+}

--- a/tests/Stubs/LogTestJob.php
+++ b/tests/Stubs/LogTestJob.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Stubs;
+
+use Otsch\Ppq\PpqJob;
+
+class LogTestJob extends PpqJob
+{
+    public function invoke(): void
+    {
+        $this->logger->info('some info');
+
+        $this->logger->warning('ohoh, this is a warning');
+
+        $this->logger->notice('Just want you to know that...');
+    }
+}

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Otsch\Ppq\Utils;
+
+it('tries until the callback returns true if max tries aren\'t reached', function () {
+    $before = (int) (microtime(true) * 1000000);
+
+    Utils::tryUntil(function () use ($before) {
+        return ($before + 150000) < (int) (microtime(true) * 1000000);
+    });
+
+    $after = (int) (microtime(true) * 1000000);
+
+    expect($after - $before)->toBeGreaterThan(150000);
+
+    expect($after - $before)->toBeLessThan(200000);
+});
+
+it('tries until the max tries limit is reached when it does not return true until then', function () {
+    $before = (int) (microtime(true) * 1000000);
+
+    Utils::tryUntil(function () use ($before) {
+        return ($before + 150000) < (int) (microtime(true) * 1000000);
+    }, maxTries: 10);
+
+    $after = (int) (microtime(true) * 1000000);
+
+    expect($after - $before)->toBeGreaterThan(100000);
+
+    expect($after - $before)->toBeLessThan(150000);
+});

--- a/tests/WorkerProcessTest.php
+++ b/tests/WorkerProcessTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use Otsch\Ppq\Config;
+use Otsch\Ppq\Ppq;
+use Otsch\Ppq\WorkerProcess;
+
+beforeEach(function () {
+    Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
+
+    if (file_exists(Ppq::dataPath('workerprocess'))) {
+        unlink(Ppq::dataPath('workerprocess'));
+    }
+});
+
+afterAll(function () {
+    if (file_exists(Ppq::dataPath('workerprocess'))) {
+        unlink(Ppq::dataPath('workerprocess'));
+    }
+});
+
+it('writes pid and time to the workerprocess file in the datapath when set() is called', function () {
+    expect(WorkerProcess::get())->toBeEmpty();
+
+    WorkerProcess::set();
+
+    expect(file_exists(Ppq::dataPath('workerprocess')))->toBeTrue();
+
+    $processData = WorkerProcess::get();
+
+    expect($processData)->toBeArray();
+
+    /** @var array<string, int> $processData */
+
+    expect($processData)->toHaveKey('pid')->toHaveKey('time');
+
+    expect($processData['pid'])->toBe(getmypid());
+
+    expect((microtime(true) * 1000000) - $processData['time'])->toBeLessThan(100000);
+});
+
+test(
+    'isWorking() is true after set() is called, if set() or heartbeat() is not called after that, it automatically ' .
+    'returns true, one second later',
+    function () {
+        expect(WorkerProcess::isWorking())->toBeFalse();
+
+        WorkerProcess::set();
+
+        expect(WorkerProcess::isWorking())->toBeTrue();
+
+        $time = WorkerProcess::getTime();
+
+        while (($time + 950000) > (int) (microtime(true) * 1000000)) {
+            expect(WorkerProcess::isWorking())->toBeTrue();
+
+            usleep(50000);
+        }
+
+        usleep(50000);
+
+        expect($time + 1000000)->toBeLessThan((int) (microtime(true) * 1000000));
+
+        expect(WorkerProcess::isWorking())->toBeFalse();
+    }
+);
+
+test('heartbeat() updates the time', function () {
+    WorkerProcess::set();
+
+    $time = WorkerProcess::getTime();
+
+    WorkerProcess::heartbeat();
+
+    expect(WorkerProcess::getTime())->toBeGreaterThan($time);
+});
+
+it('persists the pid', function () {
+    expect(WorkerProcess::getPid())->toBeNull();
+
+    WorkerProcess::set();
+
+    expect(WorkerProcess::getPid())->toBeInt();
+});
+
+it('resets the persisted pid and time when unset() is called', function () {
+    WorkerProcess::set();
+
+    expect(WorkerProcess::getPid())->toBeInt();
+
+    expect(WorkerProcess::getTime())->toBeInt();
+
+    WorkerProcess::unset();
+
+    expect(WorkerProcess::getPid())->toBeNull();
+
+    expect(WorkerProcess::getTime())->toBeNull();
+});

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -11,8 +11,6 @@ use Stubs\TestJob;
 
 beforeEach(function () {
     Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
-
-    WorkerProcess::work();
 });
 
 beforeAll(function () {

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
 beforeAll(function () {
     Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
 
-    WorkerProcess::work('WorkerTest');
+    WorkerProcess::work();
 });
 
 afterAll(function () {

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -18,7 +18,7 @@ beforeAll(function () {
 
     helper_cleanUpDataPathQueueFiles();
 
-    WorkerProcess::work();
+    WorkerProcess::work('WorkerTest');
 });
 
 afterAll(function () {

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -108,8 +108,6 @@ it('stops working the queues when it receives the stop signal', function () {
         return \Otsch\Ppq\WorkerProcess::isWorking() === false;
     });
 
-    var_dump(Config::getDriver()->get($job->id)?->status);
-
     expect(Config::getDriver()->get($job->id)?->status)->toBe(QueueJobStatus::finished);
 
     expect(\Otsch\Ppq\WorkerProcess::isWorking())->toBeFalse();

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -42,7 +42,7 @@ it('processes queue jobs', function () {
         }
 
         return $updatedJob->status === QueueJobStatus::finished ? $updatedJob : false;
-    });
+    }, sleep: 30000);
 
     expect($finishedJob)->toBeInstanceOf(QueueRecord::class);
 

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
 beforeAll(function () {
     Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
 
-    WorkerProcess::work();
+    WorkerProcess::work('WorkerTest');
 });
 
 afterAll(function () {

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -11,12 +11,16 @@ use Otsch\Ppq\Ppq;
 use Stubs\TestJob;
 
 beforeEach(function () {
+    var_dump('before each');
+
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
     WorkerProcess::work();
 });
 
 beforeAll(function () {
+    var_dump('before all');
+
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
     helper_cleanUpDataPathQueueFiles();
@@ -25,6 +29,8 @@ beforeAll(function () {
 });
 
 afterAll(function () {
+    var_dump('after all');
+
     WorkerProcess::stop();
 });
 

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -1,6 +1,7 @@
 <?php
 
-use Integration\WorkerProcess;
+namespace Integration;
+
 use Otsch\Ppq\Config;
 use Otsch\Ppq\Dispatcher;
 use Otsch\Ppq\Entities\QueueRecord;

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -24,8 +24,6 @@ beforeAll(function () {
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
     helper_cleanUpDataPathQueueFiles();
-
-    WorkerProcess::work();
 });
 
 afterAll(function () {

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -15,7 +15,7 @@ beforeEach(function () {
 
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
-    WorkerProcess::work();
+    WorkerProcess::work('CancelJobTest');
 });
 
 beforeAll(function () {

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -11,7 +11,7 @@ use Otsch\Ppq\Ppq;
 use Stubs\TestJob;
 
 beforeEach(function () {
-    var_dump('before each');
+    var_dump('before each CancelJobTest');
 
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
@@ -19,7 +19,7 @@ beforeEach(function () {
 });
 
 beforeAll(function () {
-    var_dump('before all');
+    var_dump('before all CancelJobTest');
 
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
@@ -27,7 +27,7 @@ beforeAll(function () {
 });
 
 afterAll(function () {
-    var_dump('after all');
+    var_dump('after all CancelJobTest');
 
     WorkerProcess::stop();
 });

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -21,7 +21,7 @@ beforeAll(function () {
 
     helper_cleanUpDataPathQueueFiles();
 
-    WorkerProcess::work('CancelJobTest');
+    WorkerProcess::work();
 });
 
 afterAll(function () {
@@ -70,7 +70,7 @@ it('cancels a running job', function () {
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::cancelled);
 
-    $updatedJob = Utils::tryUntil(function () use ($job) {
+    Utils::tryUntil(function () use ($job) {
         $job = Ppq::find($job->id);
 
         return $job?->pid === null ? $job : false;

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -8,27 +8,22 @@ use Otsch\Ppq\Entities\QueueRecord;
 use Otsch\Ppq\Entities\Values\QueueJobStatus;
 use Otsch\Ppq\Kernel;
 use Otsch\Ppq\Ppq;
+use Otsch\Ppq\Utils;
 use Stubs\TestJob;
 
 beforeEach(function () {
-    var_dump('before each CancelJobTest');
-
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+});
+
+beforeAll(function () {
+    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+
+    helper_cleanUpDataPathQueueFiles();
 
     WorkerProcess::work('CancelJobTest');
 });
 
-beforeAll(function () {
-    var_dump('before all CancelJobTest');
-
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
-
-    helper_cleanUpDataPathQueueFiles();
-});
-
 afterAll(function () {
-    var_dump('after all CancelJobTest');
-
     WorkerProcess::stop();
 });
 
@@ -56,7 +51,7 @@ it('cancels a running job', function () {
         ->args(['countTo' => 99999999])
         ->dispatch();
 
-    $job = helper_tryUntil(function () use ($job) {
+    $job = Utils::tryUntil(function () use ($job) {
         $job = Ppq::find($job->id);
 
         return $job?->status === QueueJobStatus::running ? $job : false;
@@ -74,7 +69,7 @@ it('cancels a running job', function () {
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::cancelled);
 
-    $job = helper_tryUntil(function () use ($job) {
+    Utils::tryUntil(function () use ($job) {
         $job = Ppq::find($job->id);
 
         return $job?->pid === null ? $job : false;

--- a/tests/_integration/ClearQueueTest.php
+++ b/tests/_integration/ClearQueueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Integration;
+
 use Otsch\Ppq\Config;
 use Otsch\Ppq\Dispatcher;
 use Otsch\Ppq\Kernel;

--- a/tests/_integration/ClearQueueTest.php
+++ b/tests/_integration/ClearQueueTest.php
@@ -10,11 +10,19 @@ use Stubs\TestJob;
 
 beforeEach(function () {
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+
+    helper_cleanUpDataPathQueueFiles();
 });
 
 beforeAll(function () {
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
+    helper_cleanUpDataPathQueueFiles();
+
+    WorkerProcess::stop();
+});
+
+afterAll(function () {
     helper_cleanUpDataPathQueueFiles();
 });
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -23,7 +23,7 @@ beforeAll(function () {
 
     helper_cleanUpDataPathQueueFiles();
 
-    WorkerProcess::work();
+    WorkerProcess::work('JobLogTest');
 
     $simpleLogTestJob = new QueueRecord('other_queue', LogTestJob::class, id: '1');
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -4,6 +4,7 @@ namespace Integration;
 
 use Otsch\Ppq\Config;
 use Otsch\Ppq\Dispatcher;
+use Otsch\Ppq\Entities\Values\QueueJobStatus;
 use Otsch\Ppq\Kernel;
 use Otsch\Ppq\Logs;
 use Otsch\Ppq\Ppq;
@@ -35,8 +36,10 @@ it('logs output from queue jobs to a log file in expected path', function () {
         ->job(LogTestJob::class)
         ->dispatch();
 
-    helper_tryUntil(function () {
-        return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
+    helper_tryUntil(function () use ($job) {
+        return count(Ppq::waiting('other_queue')) === 0 &&
+            count(Ppq::running('other_queue')) === 0 &&
+            Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, sleep: 50000);
 
     $logFilePath = Logs::queueJobLogPath($job);
@@ -71,8 +74,10 @@ test('the logs command prints the last 1000 lines by default', function () {
         ->job(LogLinesTestJob::class)
         ->dispatch();
 
-    helper_tryUntil(function () {
-        return count(Ppq::waiting('default')) === 0 && count(Ppq::running('default')) === 0;
+    helper_tryUntil(function () use ($job) {
+        return count(Ppq::waiting('default')) === 0 &&
+            count(Ppq::running('default')) === 0 &&
+            Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, sleep: 50000);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id);
@@ -95,8 +100,10 @@ test('the logs command prints only the last x lines with --lines parameter', fun
         ->job(LogLinesTestJob::class)
         ->dispatch();
 
-    helper_tryUntil(function () {
-        return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
+    helper_tryUntil(function () use ($job) {
+        return count(Ppq::waiting('other_queue')) === 0 &&
+            count(Ppq::running('other_queue')) === 0 &&
+            Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, sleep: 50000);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=10');
@@ -119,8 +126,10 @@ test('the logs command prints the whole log with --lines=all', function () {
         ->job(LogLinesTestJob::class)
         ->dispatch();
 
-    helper_tryUntil(function () {
-        return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
+    helper_tryUntil(function () use ($job) {
+        return count(Ppq::waiting('other_queue')) === 0 &&
+            count(Ppq::running('other_queue')) === 0 &&
+            Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, sleep: 50000);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=all');

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -40,7 +40,7 @@ it('logs output from queue jobs to a log file in expected path', function () {
         return count(Ppq::waiting('other_queue')) === 0 &&
             count(Ppq::running('other_queue')) === 0 &&
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
-    }, sleep: 50000);
+    }, maxTries: 500, sleep: 50000);
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 
@@ -80,7 +80,7 @@ test('the logs command prints the last 1000 lines by default', function () {
         return count(Ppq::waiting('default')) === 0 &&
             count(Ppq::running('default')) === 0 &&
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
-    }, sleep: 50000);
+    }, maxTries: 500, sleep: 50000);
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 
@@ -108,7 +108,7 @@ test('the logs command prints only the last x lines with --lines parameter', fun
         return count(Ppq::waiting('other_queue')) === 0 &&
             count(Ppq::running('other_queue')) === 0 &&
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
-    }, sleep: 50000);
+    }, maxTries: 500, sleep: 50000);
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 
@@ -136,7 +136,7 @@ test('the logs command prints the whole log with --lines=all', function () {
         return count(Ppq::waiting('other_queue')) === 0 &&
             count(Ppq::running('other_queue')) === 0 &&
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
-    }, sleep: 50000);
+    }, maxTries: 500, sleep: 50000);
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -15,8 +15,6 @@ beforeEach(function () {
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
     helper_cleanUpDataPathQueueFiles();
-
-    WorkerProcess::work();
 });
 
 beforeAll(function () {

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -42,6 +42,8 @@ it('logs output from queue jobs to a log file in expected path', function () {
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, maxTries: 500, sleep: 50000);
 
+    var_dump(WorkerProcess::$process?->getOutput());
+
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 
     $logFilePath = Logs::queueJobLogPath($job);
@@ -82,6 +84,8 @@ test('the logs command prints the last 1000 lines by default', function () {
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, maxTries: 500, sleep: 50000);
 
+    var_dump(WorkerProcess::$process?->getOutput());
+
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id);
@@ -110,6 +114,8 @@ test('the logs command prints only the last x lines with --lines parameter', fun
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, maxTries: 500, sleep: 50000);
 
+    var_dump(WorkerProcess::$process?->getOutput());
+
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=10');
@@ -137,6 +143,8 @@ test('the logs command prints the whole log with --lines=all', function () {
             count(Ppq::running('other_queue')) === 0 &&
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, maxTries: 500, sleep: 50000);
+
+    var_dump(WorkerProcess::$process?->getOutput());
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -26,6 +26,8 @@ beforeAll(function () {
 
 afterAll(function () {
     WorkerProcess::stop();
+
+    helper_cleanUpDataPathQueueFiles();
 });
 
 it('logs output from queue jobs to a log file in expected path', function () {

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Integration;
+
+use Otsch\Ppq\Config;
+use Otsch\Ppq\Dispatcher;
+use Otsch\Ppq\Kernel;
+use Otsch\Ppq\Logs;
+use Otsch\Ppq\Ppq;
+use Stubs\LogLinesTestJob;
+use Stubs\LogTestJob;
+
+beforeEach(function () {
+    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+
+    WorkerProcess::work();
+});
+
+beforeAll(function () {
+    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+
+    helper_cleanUpDataPathQueueFiles();
+
+    WorkerProcess::work();
+});
+
+afterAll(function () {
+    WorkerProcess::stop();
+});
+
+it('logs output from queue jobs to a log file in expected path', function () {
+    $job = Dispatcher::queue('other_queue')
+        ->job(LogTestJob::class)
+        ->dispatch();
+
+    helper_tryUntil(function () {
+        return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
+    });
+
+    $logFilePath = Logs::queueJobLogPath($job);
+
+    expect(file_exists($logFilePath))->toBeTrue();
+
+    $logFileContent = file_get_contents($logFilePath);
+
+    expect($logFileContent)->toContain('[INFO] some info');
+
+    expect($logFileContent)->toContain('[WARNING] ohoh, this is a warning');
+
+    expect($logFileContent)->toContain('[NOTICE] Just want you to know that...');
+
+    $logCommand = Kernel::ppqCommand('logs ' . $job->id);
+
+    $logCommand->run();
+
+    expect($logCommand->isSuccessful())->toBeTrue();
+
+    $logCommandOutput = $logCommand->getOutput();
+
+    expect($logCommandOutput)->toContain('[INFO] some info');
+
+    expect($logCommandOutput)->toContain('[WARNING] ohoh, this is a warning');
+
+    expect($logCommandOutput)->toContain('[NOTICE] Just want you to know that...');
+});
+
+test('the logs command prints the last 1000 lines by default', function () {
+    $job = Dispatcher::queue('default')
+        ->job(LogLinesTestJob::class)
+        ->dispatch();
+
+    helper_tryUntil(function () {
+        return count(Ppq::waiting('default')) === 0 && count(Ppq::running('default')) === 0;
+    });
+
+    $logCommand = Kernel::ppqCommand('logs ' . $job->id);
+
+    $logCommand->run();
+
+    expect($logCommand->isSuccessful())->toBeTrue();
+
+    $logCommandOutput = $logCommand->getOutput();
+
+    $logCommandOutputLines = explode(PHP_EOL, $logCommandOutput);
+
+    expect($logCommandOutputLines[0])->toContain('[INFO] 2001');
+
+    expect($logCommandOutputLines[999])->toContain('[INFO] 3000');
+});
+
+test('the logs command prints only the last x lines with --lines parameter', function () {
+    $job = Dispatcher::queue('other_queue')
+        ->job(LogLinesTestJob::class)
+        ->dispatch();
+
+    helper_tryUntil(function () {
+        return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
+    });
+
+    $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=10');
+
+    $logCommand->run();
+
+    expect($logCommand->isSuccessful())->toBeTrue();
+
+    $logCommandOutput = $logCommand->getOutput();
+
+    $logCommandOutputLines = explode(PHP_EOL, $logCommandOutput);
+
+    expect($logCommandOutputLines[0])->toContain('[INFO] 2991');
+
+    expect($logCommandOutputLines[9])->toContain('[INFO] 3000');
+});
+
+test('the logs command prints the whole log with --lines=all', function () {
+    $job = Dispatcher::queue('other_queue')
+        ->job(LogLinesTestJob::class)
+        ->dispatch();
+
+    helper_tryUntil(function () {
+        return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
+    });
+
+    $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=all');
+
+    $logCommand->run();
+
+    expect($logCommand->isSuccessful())->toBeTrue();
+
+    $logCommandOutput = $logCommand->getOutput();
+
+    $logCommandOutputLines = explode(PHP_EOL, $logCommandOutput);
+
+    expect($logCommandOutputLines[0])->toContain('[INFO] 1');
+
+    expect($logCommandOutputLines[2999])->toContain('[INFO] 3000');
+});

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -42,6 +42,8 @@ it('logs output from queue jobs to a log file in expected path', function () {
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, sleep: 50000);
 
+    expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
+
     $logFilePath = Logs::queueJobLogPath($job);
 
     expect(file_exists($logFilePath))->toBeTrue();
@@ -80,6 +82,8 @@ test('the logs command prints the last 1000 lines by default', function () {
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, sleep: 50000);
 
+    expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
+
     $logCommand = Kernel::ppqCommand('logs ' . $job->id);
 
     $logCommand->run();
@@ -106,6 +110,8 @@ test('the logs command prints only the last x lines with --lines parameter', fun
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, sleep: 50000);
 
+    expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
+
     $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=10');
 
     $logCommand->run();
@@ -131,6 +137,8 @@ test('the logs command prints the whole log with --lines=all', function () {
             count(Ppq::running('other_queue')) === 0 &&
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, sleep: 50000);
+
+    expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=all');
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -12,12 +12,16 @@ use Stubs\LogLinesTestJob;
 use Stubs\LogTestJob;
 
 beforeEach(function () {
+    var_dump('before each JobLogTest');
+
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
     helper_cleanUpDataPathQueueFiles();
 });
 
 beforeAll(function () {
+    var_dump('before all JobLogTest');
+
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
     helper_cleanUpDataPathQueueFiles();
@@ -26,6 +30,8 @@ beforeAll(function () {
 });
 
 afterAll(function () {
+    var_dump('after all JobLogTest');
+
     WorkerProcess::stop();
 
     helper_cleanUpDataPathQueueFiles();

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -26,7 +26,7 @@ beforeAll(function () {
 
     helper_cleanUpDataPathQueueFiles();
 
-    WorkerProcess::work();
+    WorkerProcess::work('JobLogTest');
 });
 
 afterAll(function () {

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -23,7 +23,7 @@ beforeAll(function () {
 
     helper_cleanUpDataPathQueueFiles();
 
-    WorkerProcess::work('JobLogTest');
+    WorkerProcess::work();
 
     $simpleLogTestJob = new QueueRecord('other_queue', LogTestJob::class, id: '1');
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -35,7 +35,7 @@ it('logs output from queue jobs to a log file in expected path', function () {
 
     helper_tryUntil(function () {
         return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
-    });
+    }, sleep: 50000);
 
     $logFilePath = Logs::queueJobLogPath($job);
 
@@ -71,7 +71,7 @@ test('the logs command prints the last 1000 lines by default', function () {
 
     helper_tryUntil(function () {
         return count(Ppq::waiting('default')) === 0 && count(Ppq::running('default')) === 0;
-    });
+    }, sleep: 50000);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id);
 
@@ -95,7 +95,7 @@ test('the logs command prints only the last x lines with --lines parameter', fun
 
     helper_tryUntil(function () {
         return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
-    });
+    }, sleep: 50000);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=10');
 
@@ -119,7 +119,7 @@ test('the logs command prints the whole log with --lines=all', function () {
 
     helper_tryUntil(function () {
         return count(Ppq::waiting('other_queue')) === 0 && count(Ppq::running('other_queue')) === 0;
-    });
+    }, sleep: 50000);
 
     $logCommand = Kernel::ppqCommand('logs ' . $job->id . ' --lines=all');
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -43,11 +43,11 @@ beforeAll(function () {
     if (!$jobsFinished) {
         throw new Exception('Log test jobs haven\'t finished yet');
     }
+
+    WorkerProcess::stop();
 });
 
 afterAll(function () {
-    WorkerProcess::stop();
-
     helper_cleanUpDataPathQueueFiles();
 });
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -14,6 +14,8 @@ use Stubs\LogTestJob;
 beforeEach(function () {
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
+    helper_cleanUpDataPathQueueFiles();
+
     WorkerProcess::work();
 });
 
@@ -41,6 +43,8 @@ it('logs output from queue jobs to a log file in expected path', function () {
             count(Ppq::running('other_queue')) === 0 &&
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, maxTries: 500, sleep: 50000);
+
+    var_dump($job->id);
 
     var_dump(WorkerProcess::$process?->getOutput());
 
@@ -84,6 +88,8 @@ test('the logs command prints the last 1000 lines by default', function () {
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, maxTries: 500, sleep: 50000);
 
+    var_dump($job->id);
+
     var_dump(WorkerProcess::$process?->getOutput());
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
@@ -114,6 +120,8 @@ test('the logs command prints only the last x lines with --lines parameter', fun
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, maxTries: 500, sleep: 50000);
 
+    var_dump($job->id);
+
     var_dump(WorkerProcess::$process?->getOutput());
 
     expect(Ppq::find($job->id)?->status)->toBe(QueueJobStatus::finished);
@@ -143,6 +151,8 @@ test('the logs command prints the whole log with --lines=all', function () {
             count(Ppq::running('other_queue')) === 0 &&
             Ppq::find($job->id)?->status === QueueJobStatus::finished;
     }, maxTries: 500, sleep: 50000);
+
+    var_dump($job->id);
 
     var_dump(WorkerProcess::$process?->getOutput());
 

--- a/tests/_integration/WorkCommandTest.php
+++ b/tests/_integration/WorkCommandTest.php
@@ -8,7 +8,7 @@ use Otsch\Ppq\Utils;
 it('does not start a second worker process', function () {
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
-    WorkerProcess::work();
+    WorkerProcess::work('WorkCommandTest');
 
     $isWorking = Utils::tryUntil(function () {
         return \Otsch\Ppq\WorkerProcess::isWorking();

--- a/tests/_integration/WorkCommandTest.php
+++ b/tests/_integration/WorkCommandTest.php
@@ -8,7 +8,7 @@ use Otsch\Ppq\Utils;
 it('does not start a second worker process', function () {
     Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
 
-    WorkerProcess::work('WorkCommandTest');
+    WorkerProcess::work();
 
     $isWorking = Utils::tryUntil(function () {
         return \Otsch\Ppq\WorkerProcess::isWorking();

--- a/tests/_integration/WorkCommandTest.php
+++ b/tests/_integration/WorkCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Otsch\Ppq\Config;
+use Otsch\Ppq\Kernel;
+
+it('does not start a second worker process', function () {
+    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+
+    $firstWorkerProcess = Kernel::ppqCommand('work');
+
+    $firstWorkerProcess->start();
+
+    usleep(50000);
+
+    $secondWorkerProcess = Kernel::ppqCommand('work');
+
+    $secondWorkerProcess->run();
+
+    $firstWorkerProcess->stop(0);
+
+    expect($firstWorkerProcess->getOutput())->not()->toContain('Queues are already working');
+
+    expect($secondWorkerProcess->getOutput())->toContain('Queues are already working');
+});

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -14,14 +14,14 @@ class WorkerProcess
      * @return void
      * @throws Exception
      */
-    public static function work(): void
+    public static function work(string $startingTest = ''): void
     {
         if (self::$process && !self::$process->isRunning()) {
             self::stop();
         }
 
         if (!self::$process) {
-            self::$process = Kernel::ppqCommand('work');
+            self::$process = Kernel::ppqCommand('work --startingtest=' . $startingTest);
 
             debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
 

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -23,6 +23,8 @@ class WorkerProcess
         if (!self::$process) {
             self::$process = Kernel::ppqCommand('work');
 
+            var_dump('start worker process');
+
             self::$process->start();
 
             usleep(50000);
@@ -44,6 +46,8 @@ class WorkerProcess
     public static function stop(): void
     {
         if (self::$process) {
+            var_dump('stop worker process');
+
             self::$process->stop();
 
             self::$process = null;

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -118,13 +118,13 @@ class WorkerProcess
         $otherWorkerPid = \Otsch\Ppq\WorkerProcess::getPid();
 
         if (!$otherWorkerPid) {
-            throw new Exception('WorkerProcess thinks that a worker is running but has no pid.');
+            return;
         }
 
         $otherWorkerCommand = Processes::getCommandByPid($otherWorkerPid);
 
         if (!$otherWorkerCommand) {
-            throw new Exception('Can\'t get command of other worker process.');
+            return;
         }
 
         if (

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -23,6 +23,8 @@ class WorkerProcess
         if (!self::$process) {
             self::$process = Kernel::ppqCommand('work');
 
+            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+
             var_dump('start worker process');
 
             self::$process->start();

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -52,6 +52,8 @@ class WorkerProcess
 
             self::$process->stop();
 
+            var_dump(self::$process->getOutput());
+
             self::$process = null;
 
             usleep(30000);

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -136,10 +136,16 @@ class WorkerProcess
                 self::$processCommand // @phpstan-ignore-line
             )
         ) {
-            if (Processes::kill($otherWorkerPid) || Processes::isZombie($otherWorkerPid)) {
-                \Otsch\Ppq\WorkerProcess::unset();
-            } else {
-                throw new Exception('Failed to kill worker sub-process ' . $otherWorkerPid);
+            $stoppedWorking = Utils::tryUntil(function () {
+                return \Otsch\Ppq\WorkerProcess::isWorking() === false;
+            });
+
+            if (!$stoppedWorking) {
+                if (Processes::kill($otherWorkerPid) || Processes::isZombie($otherWorkerPid)) {
+                    \Otsch\Ppq\WorkerProcess::unset();
+                } else {
+                    throw new Exception('Failed to kill worker sub-process ' . $otherWorkerPid);
+                }
             }
         } elseif (Processes::isZombie($otherWorkerPid)) {
             \Otsch\Ppq\WorkerProcess::unset();

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -50,7 +50,7 @@ class WorkerProcess
         if (self::$process) {
             var_dump('stop worker process');
 
-            $exitCode = self::$process->stop();
+            $exitCode = self::$process->stop(0);
 
             var_dump($exitCode);
 

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -77,10 +77,14 @@ class WorkerProcess
             if (!self::$process->isRunning()) {
                 self::$process->stop(0);
 
-                usleep(50000);
+                if (is_int(self::$pid)) {
+                    Utils::tryUntil(function () {
+                        return is_int(self::$pid) && Processes::pidStillExists(self::$pid) === false;
+                    });
 
-                if (is_int(self::$pid) && Processes::pidStillExists(self::$pid)) {
-                    throw new Exception('Stopping worker process failed');
+                    if (Processes::pidStillExists(self::$pid)) {
+                        throw new Exception('Stopping worker process failed');
+                    }
                 }
 
                 if (\Otsch\Ppq\WorkerProcess::isWorking()) {
@@ -92,11 +96,13 @@ class WorkerProcess
                 if (is_int(self::$pid) && Processes::pidStillExists(self::$pid)) {
                     self::$process->stop(0);
 
-                    usleep(50000);
-                }
+                    Utils::tryUntil(function () {
+                        return is_int(self::$pid) && Processes::pidStillExists(self::$pid) === false;
+                    });
 
-                if (is_int(self::$pid) && Processes::pidStillExists(self::$pid)) {
-                    throw new Exception('Stopping worker process failed');
+                    if (Processes::pidStillExists(self::$pid)) { // @phpstan-ignore-line
+                        throw new Exception('Stopping worker process failed');
+                    }
                 }
 
                 if (\Otsch\Ppq\WorkerProcess::isWorking()) {

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -3,16 +3,25 @@
 namespace Integration;
 
 use Exception;
+use Otsch\Ppq\Exceptions\MissingDataPathException;
 use Otsch\Ppq\Kernel;
+use Otsch\Ppq\Processes;
+use Otsch\Ppq\Utils;
 use Symfony\Component\Process\Process;
 
 class WorkerProcess
 {
     public static ?Process $process = null;
 
+    public static ?int $pid = null;
+
+    public static ?string $processCommand = null;
+
     /**
+     * @param string $startingTest
      * @return void
      * @throws Exception
+     * @throws MissingDataPathException
      */
     public static function work(string $startingTest = ''): void
     {
@@ -21,52 +30,99 @@ class WorkerProcess
         }
 
         if (!self::$process) {
+            if (\Otsch\Ppq\WorkerProcess::isWorking()) {
+                throw new Exception('Worker already working: ' . (\Otsch\Ppq\WorkerProcess::getPid() ?? 'unknown pid'));
+            }
+
             self::$process = Kernel::ppqCommand('work --startingtest=' . $startingTest);
-
-            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
-
-            var_dump('start worker process');
 
             self::$process->start();
 
-            usleep(50000);
+            $isWorking = Utils::tryUntil(function () {
+                return \Otsch\Ppq\WorkerProcess::isWorking();
+            });
 
-            if (!self::$process->isRunning()) {
-                if (self::$process->isSuccessful()) {
-                    throw new Exception(
-                        'Looks like worker process immediately stopped. Output: ' . self::$process->getOutput()
-                    );
-                } else {
-                    throw new Exception(
-                        'Looks like worker process immediately died. Error output: ' . self::$process->getErrorOutput()
-                    );
-                }
+            if (!$isWorking) {
+                throw new Exception('Worker process immediately died: ' . self::$process->getOutput());
+            }
+
+            self::$pid = self::$process->getPid();
+
+            if (is_int(self::$pid)) {
+                self::$processCommand = Processes::getCommandByPid(self::$pid);
             }
         }
     }
 
+    /**
+     * @throws Exception
+     * @throws MissingDataPathException
+     */
     public static function stop(): void
     {
         if (self::$process) {
-            var_dump('stop worker process');
+            if (!self::$process->isRunning()) {
+                self::$process->stop(0);
 
-            $workerProcessPid = self::$process->getPid();
+                if (\Otsch\Ppq\WorkerProcess::isWorking()) {
+                    self::tryToFindAndKillWorkerSubProcessZombie();
+                }
 
-            var_dump('worker process pid: ' . $workerProcessPid);
+                self::resetProcessData();
+            } else {
+                self::$process->stop(0);
 
-            $exitCode = self::$process->stop(0);
+                if (\Otsch\Ppq\WorkerProcess::isWorking()) {
+                    self::tryToFindAndKillWorkerSubProcessZombie();
+                }
 
-            var_dump($exitCode);
-
-            var_dump(self::$process->getOutput());
-
-            if (is_int($workerProcessPid)) {
-                var_dump(\Otsch\Ppq\Process::runningPhpProcessWithPidExists($workerProcessPid));
+                self::resetProcessData();
             }
-
-            self::$process = null;
-
-            usleep(30000);
         }
+    }
+
+    /**
+     * @throws Exception
+     * @throws MissingDataPathException
+     */
+    protected static function tryToFindAndKillWorkerSubProcessZombie(): void
+    {
+        $otherWorkerPid = \Otsch\Ppq\WorkerProcess::getPid();
+
+        if (!$otherWorkerPid) {
+            throw new Exception('WorkerProcess thinks that a worker is running but has no pid.');
+        }
+
+        $otherWorkerCommand = Processes::getCommandByPid($otherWorkerPid);
+
+        if (!$otherWorkerCommand) {
+            throw new Exception('Can\'t get command of other worker process.');
+        }
+
+        if (
+            Processes::isSubProcessOf(
+                $otherWorkerPid,
+                $otherWorkerCommand,
+                self::$pid, // @phpstan-ignore-line
+                self::$processCommand // @phpstan-ignore-line
+            )
+        ) {
+            if (Processes::kill($otherWorkerPid)) {
+                \Otsch\Ppq\WorkerProcess::unset();
+            } else {
+                throw new Exception('Failed to kill worker sub-process ' . $otherWorkerPid);
+            }
+        } else {
+            throw new Exception('Untracked worker process running: ' . $otherWorkerPid . ' - ' . $otherWorkerCommand);
+        }
+    }
+
+    protected static function resetProcessData(): void
+    {
+        self::$process = null;
+
+        self::$pid = null;
+
+        self::$processCommand = null;
     }
 }

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -61,6 +61,8 @@ class WorkerProcess
 
             self::$pid = self::$process->getPid();
 
+            self::logger()->info('Started worker process ' . self::$pid . ' - ' . $startingTest);
+
             if (is_int(self::$pid)) {
                 self::$processCommand = Processes::getCommandByPid(self::$pid);
             }

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -86,12 +86,6 @@ class WorkerProcess
                         throw new Exception('Stopping worker process failed');
                     }
                 }
-
-                if (\Otsch\Ppq\WorkerProcess::isWorking()) {
-                    self::tryToFindAndKillWorkerSubProcessZombie();
-                }
-
-                self::resetProcessData();
             } else {
                 if (is_int(self::$pid) && Processes::pidStillExists(self::$pid)) {
                     self::$process->stop(0);
@@ -104,13 +98,13 @@ class WorkerProcess
                         throw new Exception('Stopping worker process failed');
                     }
                 }
-
-                if (\Otsch\Ppq\WorkerProcess::isWorking()) {
-                    self::tryToFindAndKillWorkerSubProcessZombie();
-                }
-
-                self::resetProcessData();
             }
+
+            if (\Otsch\Ppq\WorkerProcess::isWorking()) {
+                self::tryToFindAndKillWorkerSubProcessZombie();
+            }
+
+            self::resetProcessData();
         }
     }
 

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -53,6 +53,8 @@ class WorkerProcess
             self::$process->stop();
 
             self::$process = null;
+
+            usleep(30000);
         }
     }
 }

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -50,11 +50,19 @@ class WorkerProcess
         if (self::$process) {
             var_dump('stop worker process');
 
+            $workerProcessPid = self::$process->getPid();
+
+            var_dump('worker process pid: ' . $workerProcessPid);
+
             $exitCode = self::$process->stop(0);
 
             var_dump($exitCode);
 
             var_dump(self::$process->getOutput());
+
+            if (is_int($workerProcessPid)) {
+                var_dump(\Otsch\Ppq\Process::runningPhpProcessWithPidExists($workerProcessPid));
+            }
 
             self::$process = null;
 

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -31,12 +31,11 @@ class WorkerProcess
     }
 
     /**
-     * @param string $startingTest
      * @return void
      * @throws Exception
      * @throws MissingDataPathException
      */
-    public static function work(string $startingTest = ''): void
+    public static function work(): void
     {
         if (self::$process && !self::$process->isRunning()) {
             self::stop();
@@ -47,7 +46,7 @@ class WorkerProcess
                 throw new Exception('Worker already working: ' . (\Otsch\Ppq\WorkerProcess::getPid() ?? 'unknown pid'));
             }
 
-            self::$process = Kernel::ppqCommand('work --startingtest=' . $startingTest);
+            self::$process = Kernel::ppqCommand('work');
 
             self::$process->start();
 
@@ -61,7 +60,7 @@ class WorkerProcess
 
             self::$pid = self::$process->getPid();
 
-            self::logger()->info('Started worker process ' . self::$pid . ' - ' . $startingTest);
+            self::logger()->info('Started worker process ' . self::$pid);
 
             if (is_int(self::$pid)) {
                 self::$processCommand = Processes::getCommandByPid(self::$pid);

--- a/tests/_integration/WorkerProcess.php
+++ b/tests/_integration/WorkerProcess.php
@@ -50,7 +50,9 @@ class WorkerProcess
         if (self::$process) {
             var_dump('stop worker process');
 
-            self::$process->stop();
+            $exitCode = self::$process->stop();
+
+            var_dump($exitCode);
 
             var_dump(self::$process->getOutput());
 

--- a/tests/_testdata/check-process-already-running.php
+++ b/tests/_testdata/check-process-already-running.php
@@ -1,7 +1,0 @@
-<?php
-
-use Otsch\Ppq\Process;
-
-include 'vendor/autoload.php';
-
-echo Process::runningPhpProcessContainingStringsExists(['check-process-already-running.php']) ? 'yes' : 'no';

--- a/tests/_testdata/counting.php
+++ b/tests/_testdata/counting.php
@@ -1,5 +1,0 @@
-<?php
-
-for ($i = 0; $i < 99999999; $i++) {
-    echo $i . PHP_EOL;
-}

--- a/tests/_testdata/scripts/check-process-already-running.php
+++ b/tests/_testdata/scripts/check-process-already-running.php
@@ -1,0 +1,7 @@
+<?php
+
+use Otsch\Ppq\Processes;
+
+include 'vendor/autoload.php';
+
+echo Processes::processContainingStringsExists(['check-process-already-running.php']) ? 'yes' : 'no';

--- a/tests/_testdata/scripts/counting.php
+++ b/tests/_testdata/scripts/counting.php
@@ -1,0 +1,5 @@
+<?php
+
+for ($i = 0; $i < 9999; $i++) {
+    echo $i . PHP_EOL;
+}

--- a/tests/_testdata/scripts/do-something.php
+++ b/tests/_testdata/scripts/do-something.php
@@ -1,0 +1,5 @@
+<?php
+
+for ($i = 0; $i < 9999; $i++) {
+    echo $i . PHP_EOL;
+}


### PR DESCRIPTION
The output of a job is now automatically logged to a log file with its ID. The `ppq logs <job-id>` command can be used to print the logs. By default, it prints the last 1000 lines but there's also the --lines option to get more, or all or less.