### PR TITLE
Remove oldest done jobs first

### DIFF
--- a/src/Entities/QueueRecord.php
+++ b/src/Entities/QueueRecord.php
@@ -18,7 +18,8 @@ final class QueueRecord
         public QueueJobStatus $status = QueueJobStatus::waiting,
         public readonly array $args = [],
         public ?int $pid = null,
-        ?string $id = null
+        ?string $id = null,
+        public ?int $doneTime = null,
     ) {
         $this->id = $id ?? uniqid((string) rand(1, 1000000), more_entropy: true);
     }
@@ -44,6 +45,7 @@ final class QueueRecord
             $data['args'] ?? [],
             $data['pid'] ?? null,
             $data['id'] ?? null,
+            $data['doneTime'] ?? null,
         );
     }
 
@@ -59,6 +61,12 @@ final class QueueRecord
             'status' => $this->status->name,
             'args' => $this->args,
             'pid' => $this->pid,
+            'doneTime' => $this->doneTime,
         ];
+    }
+
+    public function setDoneNow(): void
+    {
+        $this->doneTime = (int) (microtime(true) * 1000000);
     }
 }

--- a/src/Process.php
+++ b/src/Process.php
@@ -32,6 +32,8 @@ class Process
 
         $this->queueRecord->pid = null;
 
+        $this->queueRecord->setDoneNow();
+
         Config::getDriver()->update($this->queueRecord);
     }
 
@@ -46,6 +48,8 @@ class Process
         }
 
         $this->queueRecord->pid = null;
+
+        $this->queueRecord->setDoneNow();
 
         Config::getDriver()->update($this->queueRecord);
 

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -141,6 +141,8 @@ class Queue
 
         $queueJob->pid = null;
 
+        $queueJob->setDoneNow();
+
         Config::getDriver()->update($queueJob);
 
         $this->logger->warning('Updated status of lost job with id ' . $queueJob->id);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -21,4 +21,9 @@ class Utils
 
         return $callbackReturnValue;
     }
+
+    public static function currentMicrosecondsInt(): int
+    {
+        return (int) (microtime(true) * 1000000);
+    }
 }


### PR DESCRIPTION
Save the time when a job was done (finished, failed, cancelled, lost) and remove oldest done jobs first.