### PR TITLE
Fix writing files

### DIFF
--- a/src/Drivers/FileDriver.php
+++ b/src/Drivers/FileDriver.php
@@ -164,6 +164,8 @@ class FileDriver extends AbstractQueueDriver
             }
         }
 
+        ftruncate($handle, 0);
+
         fwrite($handle, serialize($queueData));
     }
 
@@ -210,7 +212,7 @@ class FileDriver extends AbstractQueueDriver
      * @return mixed[]
      * @throws Exception
      */
-    protected function getUnserializedQueueContent(string $queue, mixed $handle = null): array
+    public function getUnserializedQueueContent(string $queue, mixed $handle = null): array
     {
         return $this->getUnserializedFileContent($this->queueFileName($queue), $handle);
     }

--- a/tests/Drivers/FileDriverTest.php
+++ b/tests/Drivers/FileDriverTest.php
@@ -75,6 +75,32 @@ it('updates a job in the queue', function () {
     expect($updatedJob->id)->toBe($job->id);
 });
 
+test('the end of a previously longer content does not remain in a file when a shorter content is written', function () {
+    expect(file_get_contents(__DIR__ . '/../_testdata/datapath/queue-default'))->toBe('a:0:{}');
+
+    $driver = new FileDriver();
+
+    $job = new QueueRecord('default', TestJob::class);
+
+    $driver->add($job);
+
+    expect(file_get_contents(__DIR__ . '/../_testdata/datapath/queue-default'))->toBe(
+        'a:1:{s:29:"' . $job->id .'";a:7:{s:2:"id";s:29:"' . $job->id . '";s:5:"queue";' .
+        's:7:"default";s:8:"jobClass";s:13:"Stubs\TestJob";s:6:"status";s:7:"waiting";s:4:"args";a:0:{}s:3:"pid";N;' .
+        's:8:"doneTime";N;}}'
+    );
+
+    $job->status = QueueJobStatus::lost;
+
+    $driver->update($job);
+
+    expect(file_get_contents(__DIR__ . '/../_testdata/datapath/queue-default'))->toBe(
+        'a:1:{s:29:"' . $job->id .'";a:7:{s:2:"id";s:29:"' . $job->id . '";s:5:"queue";' .
+        's:7:"default";s:8:"jobClass";s:13:"Stubs\TestJob";s:6:"status";s:4:"lost";s:4:"args";a:0:{}s:3:"pid";N;' .
+        's:8:"doneTime";N;}}'
+    );
+});
+
 it('forgets a job', function () {
     $driver = new FileDriver();
 


### PR DESCRIPTION
There was an issue when writing to files when using stream resource and ftruncate() isn't called before fwrite(). If the new content is shorter than the content before, it writes the new content from position 0 (as it's always rewinding after reading), but the part from the previous content that is longer than the new content remains at the end of the file.

For example, if this is the content before writing: `old content that is longer than the new content`

And this is the new content you want to write:
`new shorter content`

Actually the content after write will be:
`new shorter content longer than the new content`

Weirdly unserialize seems to still work with such more or less broken file content.