### PR TITLE
Fix cancelling jobs

### DIFF
--- a/src/Processes.php
+++ b/src/Processes.php
@@ -114,10 +114,12 @@ class Processes
 
     public static function isSubProcessOf(int $pid, string $command, int $parentPid, string $parentCommand): bool
     {
-        return $parentCommand === 'sh -c ' . $command &&
+        $splitAtGtGt = explode('>>', $parentCommand);
+
+        $parentCommandWithoutOutputToFile = $splitAtGtGt[0];
+
+        return ($parentCommand === 'sh -c ' . $command || $parentCommandWithoutOutputToFile === 'sh -c ' . $command) &&
             (
-                $pid === $parentPid - 1 ||
-                $pid === $parentPid - 2 ||
                 $pid === $parentPid + 1 ||
                 $pid === $parentPid + 2
             );

--- a/tests/Drivers/FileDriverTest.php
+++ b/tests/Drivers/FileDriverTest.php
@@ -84,8 +84,10 @@ test('the end of a previously longer content does not remain in a file when a sh
 
     $driver->add($job);
 
+    $strlenId = strlen($job->id);
+
     expect(file_get_contents(__DIR__ . '/../_testdata/datapath/queue-default'))->toBe(
-        'a:1:{s:29:"' . $job->id .'";a:7:{s:2:"id";s:29:"' . $job->id . '";s:5:"queue";' .
+        'a:1:{s:' . $strlenId . ':"' . $job->id .'";a:7:{s:2:"id";s:' . $strlenId .':"' . $job->id . '";s:5:"queue";' .
         's:7:"default";s:8:"jobClass";s:13:"Stubs\TestJob";s:6:"status";s:7:"waiting";s:4:"args";a:0:{}s:3:"pid";N;' .
         's:8:"doneTime";N;}}'
     );
@@ -95,7 +97,7 @@ test('the end of a previously longer content does not remain in a file when a sh
     $driver->update($job);
 
     expect(file_get_contents(__DIR__ . '/../_testdata/datapath/queue-default'))->toBe(
-        'a:1:{s:29:"' . $job->id .'";a:7:{s:2:"id";s:29:"' . $job->id . '";s:5:"queue";' .
+        'a:1:{s:' . $strlenId . ':"' . $job->id .'";a:7:{s:2:"id";s:' . $strlenId .':"' . $job->id . '";s:5:"queue";' .
         's:7:"default";s:8:"jobClass";s:13:"Stubs\TestJob";s:6:"status";s:4:"lost";s:4:"args";a:0:{}s:3:"pid";N;' .
         's:8:"doneTime";N;}}'
     );

--- a/tests/ProcessesTest.php
+++ b/tests/ProcessesTest.php
@@ -54,7 +54,7 @@ it(
     [123, 'php yolo.php', 121, 'php foo.php', false],
     [123, 'php vendor/bin/ppq list', 125, 'sh -c php vendor/bin/ppq logs 123.abc', false],
     [123, 'php foo.php', 122, 'sh -c php foo.php', true],
-    [123, 'php foo.php', 125, 'sh -c php foo.php', true],
+    [123, 'php foo.php', 125, 'sh -c php foo.php', false],
     [123, 'php foo.php', 126, 'sh -c php foo.php', false],
     [125, 'sh -c php foo.php', 123, 'php foo.php', false],
 ]);

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -80,7 +80,13 @@ it('cancels a running job', function () {
 
     expect(helper_containsInOneLine($workerProcessOutput, ['Started job', $job->id]))->toBeTrue();
 
-    expect(helper_containsInOneLine($workerProcessOutput, ['Cancelled running job', $job->id]))->toBeTrue();
+    expect(
+        helper_containsInOneLine($workerProcessOutput, ['Cancelled running job', $job->id]) ||
+        helper_containsInOneLine($workerProcessOutput, [
+            'should have been cancelled, but it looks like it already finished.',
+            $job->id
+        ])
+    )->toBeTrue();
 
     expect(Processes::pidStillExists($job->pid))->toBeFalse();
 });


### PR DESCRIPTION
Add the finding and killing of still running sub-processes, when a job process was stopped, again. Otherwise jobs shown as cancelled could actually still be running. If cancelling fails, reset job status to running.