### PR TITLE
Add event listeners feature

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -65,6 +65,7 @@ class Config
                 $queueName,
                 $queueConfig['concurrent_jobs'] ?? 2,
                 $queueConfig['keep_last_x_past_jobs'] ?? 100,
+                $queueConfig['listeners'] ?? [],
             );
         }
 

--- a/src/Contracts/QueueEventListener.php
+++ b/src/Contracts/QueueEventListener.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Otsch\Ppq\Contracts;
+
+use Otsch\Ppq\Entities\QueueRecord;
+
+interface QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void;
+}

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -56,6 +56,8 @@ class Dispatcher
 
         $this->driver->add($record);
 
+        $this->callEventListeners($record);
+
         $this->reset();
 
         return $record;
@@ -138,5 +140,14 @@ class Dispatcher
         $this->jobClassName = '';
 
         $this->args = [];
+    }
+
+    private function callEventListeners(QueueRecord $queueRecord): void
+    {
+        $queues = Config::getQueues();
+
+        if (isset($queues[$this->queueName])) {
+            $queues[$this->queueName]->eventListeners->callWaiting($queueRecord);
+        }
     }
 }

--- a/src/QueueEventListeners.php
+++ b/src/QueueEventListeners.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Otsch\Ppq;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+use Otsch\Ppq\Loggers\EchoLogger;
+
+class QueueEventListeners
+{
+    /**
+     * @var array<string, array<int, string|QueueEventListener>> $listeners
+     */
+    protected array $listeners = [];
+
+    /**
+     * @param array<string, string|QueueEventListener|array<int, string|QueueEventListener>> $listeners
+     */
+    public function __construct(array $listeners = [])
+    {
+        foreach ($listeners as $type => $listenerClasses) {
+            if (!in_array($type, ['waiting', 'running', 'finished', 'failed', 'lost', 'cancelled'], true)) {
+                continue;
+            }
+
+            $this->listeners[$type] = is_array($listenerClasses) ? $listenerClasses : [$listenerClasses];
+        }
+    }
+
+    public function callWaiting(QueueRecord $queueRecord): void
+    {
+        $this->call('waiting', $queueRecord);
+    }
+
+    public function callRunning(QueueRecord $queueRecord): void
+    {
+        $this->call('running', $queueRecord);
+    }
+
+    public function callFinished(QueueRecord $queueRecord): void
+    {
+        $this->call('finished', $queueRecord);
+    }
+
+    public function callFailed(QueueRecord $queueRecord): void
+    {
+        $this->call('failed', $queueRecord);
+    }
+
+    public function callLost(QueueRecord $queueRecord): void
+    {
+        $this->call('lost', $queueRecord);
+    }
+
+    public function callCancelled(QueueRecord $queueRecord): void
+    {
+        $this->call('cancelled', $queueRecord);
+    }
+
+    protected function call(string $type, QueueRecord $queueRecord): void
+    {
+        if (isset($this->listeners[$type])) {
+            foreach ($this->listeners[$type] as $key => $listener) {
+                if (is_string($listener) && class_exists($listener)) {
+                    $instance = new $listener();
+
+                    if ($instance instanceof QueueEventListener) {
+                        $this->listeners[$type][$key] = $instance;
+                    } else {
+                        (new EchoLogger())->warning(
+                            'Queue Listener ' . $listener . ' does not implement the QueueEventListener interface.'
+                        );
+                    }
+                }
+
+                if ($this->listeners[$type][$key] instanceof QueueEventListener) {
+                    $this->listeners[$type][$key]->invoke($queueRecord);
+                }
+            }
+        }
+    }
+}

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -4,6 +4,7 @@ use Otsch\Ppq\Config;
 use Otsch\Ppq\Entities\QueueRecord;
 use Otsch\Ppq\Entities\Values\QueueJobStatus;
 use Otsch\Ppq\Process;
+use Otsch\Ppq\QueueEventListeners;
 use PHPUnit\Framework\TestCase;
 use Stubs\TestJob;
 
@@ -24,7 +25,7 @@ it('finishes a process that was successfully finished', function () {
 
     $process = new Process($queueRecord, $process); // @phpstan-ignore-line
 
-    $process->finish();
+    $process->finish(new QueueEventListeners());
 
     expect($queueRecord->status)->toBe(QueueJobStatus::finished);
 
@@ -52,7 +53,7 @@ it('finishes a process that failed', function () {
 
     $process = new Process($queueRecord, $process); // @phpstan-ignore-line
 
-    $process->finish();
+    $process->finish(new QueueEventListeners());
 
     expect($queueRecord->status)->toBe(QueueJobStatus::failed);
 

--- a/tests/QueueEventListenerTest.php
+++ b/tests/QueueEventListenerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Otsch\Ppq\Entities\QueueRecord;
+use Otsch\Ppq\QueueEventListeners;
+use Stubs\Listeners\DefaultFinished;
+use Stubs\Listeners\OtherQueueFailedOne;
+use Stubs\Listeners\OtherQueueFailedTwo;
+use Stubs\Listeners\TestEventListener;
+use Stubs\TestJob;
+
+beforeEach(function () {
+    TestEventListener::$staticCalled = false;
+});
+
+it(
+    'takes an array with type (waiting, running,...) as key and either single listener class names or an array of ' .
+    'listener class names as constructor argument',
+    function () {
+        $listeners = new QueueEventListeners([
+            'finished' => DefaultFinished::class,
+            'failed' => [OtherQueueFailedOne::class, OtherQueueFailedTwo::class],
+        ]);
+
+        expect($listeners)->toBeInstanceOf(QueueEventListeners::class);
+    }
+);
+
+it('calls single listeners for some event', function (string $eventName) {
+    $listeners = new QueueEventListeners([$eventName => TestEventListener::class]);
+
+    expect(TestEventListener::$staticCalled)->toBeFalse();
+
+    $eventMethodName = 'call' . ucfirst($eventName);
+
+    $listeners->$eventMethodName(new QueueRecord('default', TestJob::class));
+
+    expect(TestEventListener::$staticCalled)->toBeTrue();
+})->with(['waiting', 'running', 'finished', 'failed', 'lost', 'cancelled']);
+
+it('calls multiple listeners for some event', function (string $eventName) {
+    $listenerOne = new TestEventListener();
+
+    expect($listenerOne->called)->toBeFalse();
+
+    $listenerTwo = new TestEventListener();
+
+    expect($listenerTwo->called)->toBeFalse();
+
+    $listenerThree = new TestEventListener();
+
+    expect($listenerThree->called)->toBeFalse();
+
+    $listeners = new QueueEventListeners([
+        $eventName => [$listenerOne, $listenerTwo, $listenerThree]
+    ]);
+
+    $eventMethodName = 'call' . ucfirst($eventName);
+
+    $listeners->$eventMethodName(new QueueRecord('default', TestJob::class));
+
+    expect($listenerOne->called)->toBeTrue();
+
+    expect($listenerTwo->called)->toBeTrue();
+
+    expect($listenerThree->called)->toBeTrue();
+})->with(['waiting', 'running', 'finished', 'failed', 'lost', 'cancelled']);

--- a/tests/Stubs/Listeners/DefaultCancelled.php
+++ b/tests/Stubs/Listeners/DefaultCancelled.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class DefaultCancelled implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default cancelled called');
+    }
+}

--- a/tests/Stubs/Listeners/DefaultFailed.php
+++ b/tests/Stubs/Listeners/DefaultFailed.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class DefaultFailed implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default failed called');
+    }
+}

--- a/tests/Stubs/Listeners/DefaultFinished.php
+++ b/tests/Stubs/Listeners/DefaultFinished.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class DefaultFinished implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default finished called');
+    }
+}

--- a/tests/Stubs/Listeners/DefaultLost.php
+++ b/tests/Stubs/Listeners/DefaultLost.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class DefaultLost implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default lost called');
+    }
+}

--- a/tests/Stubs/Listeners/DefaultRunning.php
+++ b/tests/Stubs/Listeners/DefaultRunning.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class DefaultRunning implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default running called');
+    }
+}

--- a/tests/Stubs/Listeners/DefaultWaiting.php
+++ b/tests/Stubs/Listeners/DefaultWaiting.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class DefaultWaiting implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default waiting called');
+    }
+}

--- a/tests/Stubs/Listeners/OtherQueueFailedOne.php
+++ b/tests/Stubs/Listeners/OtherQueueFailedOne.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class OtherQueueFailedOne implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(
+            __DIR__ . '/../../_testdata/datapath/event-listeners-check-file',
+            'other queue failed one called ',
+            FILE_APPEND,
+        );
+    }
+}

--- a/tests/Stubs/Listeners/OtherQueueFailedThree.php
+++ b/tests/Stubs/Listeners/OtherQueueFailedThree.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class OtherQueueFailedThree implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(
+            __DIR__ . '/../../_testdata/datapath/event-listeners-check-file',
+            'other queue failed three called',
+            FILE_APPEND,
+        );
+    }
+}

--- a/tests/Stubs/Listeners/OtherQueueFailedTwo.php
+++ b/tests/Stubs/Listeners/OtherQueueFailedTwo.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class OtherQueueFailedTwo implements QueueEventListener
+{
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        file_put_contents(
+            __DIR__ . '/../../_testdata/datapath/event-listeners-check-file',
+            'other queue failed two called ',
+            FILE_APPEND,
+        );
+    }
+}

--- a/tests/Stubs/Listeners/TestEventListener.php
+++ b/tests/Stubs/Listeners/TestEventListener.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+use Otsch\Ppq\Entities\QueueRecord;
+
+class TestEventListener implements QueueEventListener
+{
+    public static bool $staticCalled = false;
+
+    public bool $called = false;
+
+    public function invoke(QueueRecord $queueRecord): void
+    {
+        $this->called = true;
+
+        self::$staticCalled = true;
+    }
+}

--- a/tests/Stubs/TestJobPhpError.php
+++ b/tests/Stubs/TestJobPhpError.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Stubs;
+
+use Otsch\Ppq\Contracts\QueueableJob;
+
+class TestJobPhpError implements QueueableJob
+{
+    public function invoke(): void
+    {
+        $foo = 'bar';
+
+        var_dumb($foo); // @phpstan-ignore-line
+    }
+}

--- a/tests/Stubs/TestJobThrowingException.php
+++ b/tests/Stubs/TestJobThrowingException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Stubs;
+
+use Exception;
+use Otsch\Ppq\Contracts\QueueableJob;
+
+class TestJobThrowingException implements QueueableJob
+{
+    public function invoke(): void
+    {
+        throw new Exception('Something went wrong');
+    }
+}

--- a/tests/_integration/QueueEventListenersTest.php
+++ b/tests/_integration/QueueEventListenersTest.php
@@ -125,7 +125,7 @@ it('calls event listeners registered for the lost event, when a job is lost', fu
 
     Utils::tryUntil(function () use ($runningQueueJob) {
         return !Processes::pidStillExists($runningQueueJob->pid);
-    }, maxTries: 1000);
+    }, maxTries: 5000);
 
     expect(Processes::pidStillExists($runningQueueJob->pid))->toBeFalse();
 

--- a/tests/_integration/QueueEventListenersTest.php
+++ b/tests/_integration/QueueEventListenersTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Integration;
+
+use Otsch\Ppq\Config;
+use Otsch\Ppq\Dispatcher;
+use Otsch\Ppq\Entities\Values\QueueJobStatus;
+use Otsch\Ppq\Kernel;
+use Otsch\Ppq\Ppq;
+use Otsch\Ppq\Processes;
+use Otsch\Ppq\Utils;
+use Stubs\TestJob;
+use Stubs\TestJobPhpError;
+use Stubs\TestJobThrowingException;
+
+beforeAll(function () {
+    Config::setPath(__DIR__ . '/../_testdata/config/event-listeners.php');
+
+    if (!file_exists(__DIR__ . '/../_testdata/datapath/event-listeners-check-file')) {
+        touch(__DIR__ . '/../_testdata/datapath/event-listeners-check-file');
+    } else {
+        file_put_contents(__DIR__ . '/../_testdata/datapath/event-listeners-check-file', '');
+    }
+
+    helper_cleanUpDataPathQueueFiles();
+
+    WorkerProcess::work();
+});
+
+beforeEach(function () {
+    Config::setPath(__DIR__ . '/../_testdata/config/event-listeners.php');
+
+    file_put_contents(__DIR__ . '/../_testdata/datapath/event-listeners-check-file', '');
+});
+
+afterAll(function () {
+    helper_cleanUpDataPathQueueFiles();
+
+    WorkerProcess::stop();
+});
+
+function helper_getListenerCheckFileContent(): string
+{
+    $fileContent = file_get_contents(__DIR__ . '/../_testdata/datapath/event-listeners-check-file');
+
+    if ($fileContent === false) {
+        return '';
+    }
+
+    return $fileContent;
+}
+
+it('calls event listeners registered for the waiting event, when a new waiting job is added', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    Dispatcher::queue('default')->job(TestJob::class)->args(['countTo' => 10])->dispatch();
+
+    expect(helper_getListenerCheckFileContent())->toBe('default waiting called');
+});
+
+it('calls event listeners registered for the running event, when a waiting job is started', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    $queueJob = Dispatcher::queue('default')->job(TestJob::class)->dispatch();
+
+    Utils::tryUntil(function () use ($queueJob) {
+        return Ppq::find($queueJob->id)?->status === QueueJobStatus::running;
+    });
+
+    expect(helper_getListenerCheckFileContent())->toBe('default running called');
+});
+
+it('calls event listeners registered for the finished event, when a job successfully finished', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    $queueJob = Dispatcher::queue('default')->job(TestJob::class)->dispatch();
+
+    Utils::tryUntil(function () use ($queueJob) {
+        return Ppq::find($queueJob->id)?->status === QueueJobStatus::finished;
+    });
+
+    expect(helper_getListenerCheckFileContent())->toBe('default finished called');
+});
+
+it('calls event listeners registered for the failed event, when a job failed', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    $queueJob = Dispatcher::queue('default')->job(TestJobThrowingException::class)->dispatch();
+
+    Utils::tryUntil(function () use ($queueJob) {
+        return Ppq::find($queueJob->id)?->status === QueueJobStatus::failed;
+    });
+
+    expect(helper_getListenerCheckFileContent())->toBe('default failed called');
+});
+
+it('calls event listeners registered for the failed event, when a job has a PHP error', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    $queueJob = Dispatcher::queue('default')->job(TestJobPhpError::class)->dispatch();
+
+    Utils::tryUntil(function () use ($queueJob) {
+        return Ppq::find($queueJob->id)?->status === QueueJobStatus::failed;
+    });
+
+    expect(helper_getListenerCheckFileContent())->toBe('default failed called');
+});
+
+it('calls event listeners registered for the lost event, when a job is lost', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    // In some environments it somehow takes pretty long to stop the worker process and then the job could already
+    // be finished before the process is stopped, so use a pretty big number to count to.
+    $queueJob = Dispatcher::queue('default')->job(TestJob::class)->args(['countTo' => 750000000])->dispatch();
+
+    $runningQueueJob = Utils::tryUntil(function () use ($queueJob) {
+        $updatedQueueJob = Ppq::find($queueJob->id);
+
+        return $updatedQueueJob?->status === QueueJobStatus::running ? $updatedQueueJob : false;
+    });
+
+    expect($runningQueueJob?->status)->toBe(QueueJobStatus::running);
+
+    WorkerProcess::stop();
+
+    Utils::tryUntil(function () use ($runningQueueJob) {
+        return !Processes::pidStillExists($runningQueueJob->pid);
+    }, maxTries: 1000);
+
+    expect(Processes::pidStillExists($runningQueueJob->pid))->toBeFalse();
+
+    expect(Ppq::find($runningQueueJob->id)?->status)->not()->toBe(QueueJobStatus::finished);
+
+    WorkerProcess::work();
+
+    $updatedQueueJob = Utils::tryUntil(function () use ($runningQueueJob) {
+        $updatedQueueJob = Ppq::find($runningQueueJob->id);
+
+        return $updatedQueueJob?->status === QueueJobStatus::lost ? $updatedQueueJob : false;
+    });
+
+    expect($updatedQueueJob?->status)->toBe(QueueJobStatus::lost);
+
+    expect(helper_getListenerCheckFileContent())->toBe('default lost called');
+});
+
+it('calls event listeners registered for the cancelled event, when a waiting job is cancelled', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    $queueJob = Dispatcher::queue('default')->job(TestJob::class)->dispatch();
+
+    $cancelCommand = Kernel::ppqCommand('cancel ' . $queueJob->id);
+
+    $cancelCommand->run();
+
+    expect($cancelCommand->isSuccessful())->toBeTrue();
+
+    Utils::tryUntil(function () use ($queueJob) {
+        return Ppq::find($queueJob->id)?->status === QueueJobStatus::cancelled;
+    });
+
+    expect(Ppq::find($queueJob->id)?->status)->toBe(QueueJobStatus::cancelled);
+
+    expect(helper_getListenerCheckFileContent())->toBe('default cancelled called');
+});
+
+it('calls event listeners registered for the cancelled event, when a running job is cancelled', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    $queueJob = Dispatcher::queue('default')->job(TestJob::class)->args(['countTo' => 99999999])->dispatch();
+
+    $updatedQueueJob = Utils::tryUntil(function () use ($queueJob) {
+        $updatedQueueJob = Ppq::find($queueJob->id);
+
+        return $updatedQueueJob?->status === QueueJobStatus::running ? $updatedQueueJob : false;
+    });
+
+    expect($updatedQueueJob->status)->toBe(QueueJobStatus::running);
+
+    $cancelCommand = Kernel::ppqCommand('cancel ' . $queueJob->id);
+
+    $cancelCommand->run();
+
+    expect($cancelCommand->isSuccessful())->toBeTrue();
+
+    $updatedQueueJob = Utils::tryUntil(function () use ($queueJob) {
+        $updatedQueueJob = Ppq::find($queueJob->id);
+
+        return $updatedQueueJob?->status === QueueJobStatus::cancelled ? $updatedQueueJob : false;
+    });
+
+    // Cancelled state is written immediately, the worker tries to actually cancel a running process on the next
+    // worker loop iteration. If actually cancelling the process fails in the worker, the status is set back to running.
+    // So, wait a little longer, because the job's status can already be cancelled but the event isn't called yet.
+    usleep(400000);
+
+    expect($updatedQueueJob?->status)->toBe(QueueJobStatus::cancelled);
+
+    expect(helper_getListenerCheckFileContent())->toBe('default cancelled called');
+});
+
+it('calls only the listeners registered for the queue the job is on', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    $queueJob = Dispatcher::queue('other_queue')->job(TestJob::class)->dispatch();
+
+    Utils::tryUntil(function () use ($queueJob) {
+        return Ppq::find($queueJob->id)?->status === QueueJobStatus::finished;
+    });
+
+    expect(helper_getListenerCheckFileContent())->toBe('');
+});
+
+it('calls all listeners registered for an event', function () {
+    expect(helper_getListenerCheckFileContent())->toBe('');
+
+    $queueJob = Dispatcher::queue('other_queue')->job(TestJobThrowingException::class)->dispatch();
+
+    Utils::tryUntil(function () use ($queueJob) {
+        return Ppq::find($queueJob->id)?->status === QueueJobStatus::failed;
+    });
+
+    expect(helper_getListenerCheckFileContent())
+        ->toBe('other queue failed one called other queue failed two called other queue failed three called');
+});

--- a/tests/_testdata/config/event-listeners.php
+++ b/tests/_testdata/config/event-listeners.php
@@ -1,0 +1,38 @@
+<?php
+
+use Otsch\Ppq\Drivers\FileDriver;
+use Stubs\Listeners\DefaultCancelled;
+use Stubs\Listeners\DefaultFailed;
+use Stubs\Listeners\DefaultFinished;
+use Stubs\Listeners\DefaultLost;
+use Stubs\Listeners\DefaultRunning;
+use Stubs\Listeners\DefaultWaiting;
+use Stubs\Listeners\OtherQueueFailedOne;
+use Stubs\Listeners\OtherQueueFailedThree;
+use Stubs\Listeners\OtherQueueFailedTwo;
+
+return [
+    'datapath' => __DIR__ . '/../datapath',
+
+    'driver' => FileDriver::class,
+
+    'queues' => [
+        'default' => [
+            'concurrent_jobs' => 2,
+            'listeners' => [
+                'waiting' => [DefaultWaiting::class],
+                'running' => DefaultRunning::class,
+                'finished' => [DefaultFinished::class],
+                'failed' => DefaultFailed::class,
+                'lost' => DefaultLost::class,
+                'cancelled' => DefaultCancelled::class,
+            ]
+        ],
+        'other_queue' => [
+            'concurrent_jobs' => 2,
+            'listeners' => [
+                'failed' => [OtherQueueFailedOne::class, OtherQueueFailedTwo::class, OtherQueueFailedThree::class],
+            ]
+        ],
+    ],
+];

--- a/tests/_testdata/scripts/counting.php
+++ b/tests/_testdata/scripts/counting.php
@@ -1,5 +1,5 @@
 <?php
 
-for ($i = 0; $i < 9999; $i++) {
+for ($i = 0; $i < 999999; $i++) {
     echo $i . PHP_EOL;
 }


### PR DESCRIPTION
Via the config you can add listeners (classes implementing the QueueEventListener interface) to certain queues. The available events are: `waiting`, `running`, `finished`, `failed`, `lost`, `cancelled`. When a listener is added to a queue in the config it will be called with each job that was just added (`waiting`), started running (`running`), just `finished`, and so on.