### PR TITLE
Improve killing processes

### DIFF
--- a/src/Processes.php
+++ b/src/Processes.php
@@ -176,6 +176,10 @@ class Processes
     {
         $command = self::runCommand('kill -9 ' . $pid);
 
+        Utils::tryUntil(function () use ($pid) {
+            return !self::pidStillExists($pid);
+        });
+
         return $command->isSuccessful() && !self::pidStillExists($pid);
     }
 


### PR DESCRIPTION
After running the kill command try to wait until pidStillExists returns false.