### PR TITLE
Fix issue with writing the index file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2022-06-22
+
+### Fixed
+* When the new content of the ppq index file was shorter than the old content, it wrote the new content starting from the beginning of the file and the part of the old content that was longer than the new content, remained at the end of the file. Fixed it be truncating the file before writing the new content.
+
 ## [0.1.0] - 2022-06-21

--- a/src/Drivers/FileDriver.php
+++ b/src/Drivers/FileDriver.php
@@ -293,6 +293,8 @@ class FileDriver extends AbstractQueueDriver
      */
     protected function saveIndex(array $index, mixed $handle): void
     {
+        ftruncate($handle, 0);
+
         fwrite($handle, serialize($index));
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -9,7 +9,7 @@ use Stubs\SimpleInMemoryDriver;
 
 function helper_configFilePath(string $configFile = 'min.php'): string
 {
-    return __DIR__ . '/_testdata/config/' . $configFile;
+    return helper_testConfigPath($configFile);
 }
 
 test(

--- a/tests/KernelTest.php
+++ b/tests/KernelTest.php
@@ -15,7 +15,7 @@ use Stubs\TestJob;
 /** @var TestCase $this */
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/_testdata/config/ppq.php');
+    Config::setPath(helper_testConfigPath('ppq.php'));
 });
 
 it('returns an existing ppqPath', function () {

--- a/tests/ListCommandTest.php
+++ b/tests/ListCommandTest.php
@@ -11,9 +11,9 @@ use Stubs\TestJob;
 
 it('lists all the waiting and running jobs in all queues', function () {
     // temporarily switch config, so the driver instance is reset.
-    Config::setPath(__DIR__ . '/_testdata/config/min.php');
+    Config::setPath(helper_testConfigPath('min.php'));
 
-    Config::setPath(__DIR__ . '/_testdata/config/ppq.php');
+    Config::setPath(helper_testConfigPath('ppq.php'));
 
     $driver = Config::getDriver();
 

--- a/tests/Loggers/FileLoggerTest.php
+++ b/tests/Loggers/FileLoggerTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 function helper_testLogFilePath(): string
 {
-    return __DIR__ . '/../_testdata/datapath/logfile';
+    return helper_testDataPath('logfile');
 }
 
 function helper_getLogFileContent(): string

--- a/tests/LogsTest.php
+++ b/tests/LogsTest.php
@@ -13,7 +13,7 @@ use Stubs\LogLinesTestJob;
 use Stubs\LogTestJob;
 
 beforeAll(function () {
-    Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 
@@ -103,21 +103,21 @@ it('prints a jobs log', function () {
 });
 
 it('tells you the log base path', function () {
-    expect(realpath(Logs::logPath()))->toBe(__DIR__ . '/_testdata/datapath/logs');
+    expect(realpath(Logs::logPath()))->toBe(helper_testDataPath('logs'));
 });
 
 it('tells you the log path for a certain queue', function () {
-    expect(Logs::queueLogPath('other_queue'))->toBe(__DIR__ . '/_testdata/config/../datapath/logs/other_queue');
+    expect(realpath(Logs::queueLogPath('other_queue')))->toBe(helper_testDataPath('logs/other_queue'));
 });
 
 it('forgets the log file for a queue job', function () {
     $job = new QueueRecord('default', LogTestJob::class, id: '123abc');
 
-    expect(file_exists(__DIR__ . '/_testdata/datapath/logs/default/' . $job->id . '.log'))->toBeTrue();
+    expect(file_exists(helper_testDataPath('logs/default/' . $job->id . '.log')))->toBeTrue();
 
     Logs::forget($job);
 
-    expect(file_exists(__DIR__ . '/_testdata/datapath/logs/default/' . $job->id . '.log'))->toBeFalse();
+    expect(file_exists(helper_testDataPath('logs/default/' . $job->id . '.log')))->toBeFalse();
 });
 
 it('creates the log dirs if they don\'t exist yet', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -39,46 +39,73 @@
 |
 */
 
+function helper_testDataPath(string $withinPath = ''): string
+{
+    if (!empty($withinPath)) {
+        $withinPath = str_starts_with($withinPath, '/') ? $withinPath : '/' . $withinPath;
+    }
+
+    return __DIR__ . '/_testdata/datapath' . $withinPath;
+}
+
+function helper_testConfigPath(string $withinPath = ''): string
+{
+    if (!empty($withinPath)) {
+        $withinPath = str_starts_with($withinPath, '/') ? $withinPath : '/' . $withinPath;
+    }
+
+    return __DIR__ . '/_testdata/config' . $withinPath;
+}
+
+function helper_testScriptPath(string $withinPath = ''): string
+{
+    if (!empty($withinPath)) {
+        $withinPath = str_starts_with($withinPath, '/') ? $withinPath : '/' . $withinPath;
+    }
+
+    return __DIR__ . '/_testdata/scripts' . $withinPath;
+}
+
 function helper_cleanUpDataPathQueueFiles(): void
 {
-    if (file_exists(__DIR__ . '/_testdata/datapath/index')) {
-        file_put_contents(__DIR__ . '/_testdata/datapath/index', 'a:0:{}');
+    if (file_exists(helper_testDataPath('index'))) {
+        file_put_contents(helper_testDataPath('index'), 'a:0:{}');
     }
 
-    if (file_exists(__DIR__ . '/_testdata/datapath/queue-default')) {
-        file_put_contents(__DIR__ . '/_testdata/datapath/queue-default', 'a:0:{}');
+    if (file_exists(helper_testDataPath('queue-default'))) {
+        file_put_contents(helper_testDataPath('queue-default'), 'a:0:{}');
     }
 
-    if (file_exists(__DIR__ . '/_testdata/datapath/queue-other_queue')) {
-        file_put_contents(__DIR__ . '/_testdata/datapath/queue-other_queue', 'a:0:{}');
+    if (file_exists(helper_testDataPath('queue-other_queue'))) {
+        file_put_contents(helper_testDataPath('queue-other_queue'), 'a:0:{}');
     }
 
-    if (file_exists(__DIR__ . '/_testdata/datapath/queue-infinite_waiting_jobs_queue')) {
-        file_put_contents(__DIR__ . '/_testdata/datapath/queue-infinite_waiting_jobs_queue', 'a:0:{}');
+    if (file_exists(helper_testDataPath('queue-infinite_waiting_jobs_queue'))) {
+        file_put_contents(helper_testDataPath('queue-infinite_waiting_jobs_queue'), 'a:0:{}');
     }
 
     // clean up logs
-    if (file_exists(__DIR__ . '/_testdata/datapath/logs')) {
+    if (file_exists(helper_testDataPath('logs'))) {
         $queues = ['default', 'other_queue', 'infinite_waiting_jobs_queue'];
 
         foreach ($queues as $queue) {
-            if (file_exists(__DIR__ . '/_testdata/datapath/logs/' . $queue)) {
-                $filesInDir = scandir(__DIR__ . '/_testdata/datapath/logs/' . $queue);
+            if (file_exists(helper_testDataPath('logs/' . $queue))) {
+                $filesInDir = scandir(helper_testDataPath('logs/' . $queue));
 
                 if (is_array($filesInDir)) {
                     foreach ($filesInDir as $file) {
                         if (str_ends_with($file, '.log')) {
-                            unlink(__DIR__ . '/_testdata/datapath/logs/' . $queue . '/' . $file);
+                            unlink(helper_testDataPath('logs/' . $queue . '/' . $file));
                         }
                     }
                 }
 
-                rmdir(__DIR__ . '/_testdata/datapath/logs/' . $queue);
+                rmdir(helper_testDataPath('logs/' . $queue));
             }
         }
 
-        if (file_exists(__DIR__ . '/_testdata/datapath/logs')) {
-            rmdir(__DIR__ . '/_testdata/datapath/logs');
+        if (file_exists(helper_testDataPath('logs'))) {
+            rmdir(helper_testDataPath('logs'));
         }
     }
 }

--- a/tests/ProcessTest.php
+++ b/tests/ProcessTest.php
@@ -11,7 +11,7 @@ use Stubs\TestJob;
 /** @var TestCase $this */
 
 it('finishes a process that was successfully finished', function () {
-    Config::setPath(__DIR__ . '/_testdata/config/ppq.php');
+    Config::setPath(helper_testConfigPath('ppq.php'));
 
     $queueRecord = new QueueRecord('default', TestJob::class);
 
@@ -35,7 +35,7 @@ it('finishes a process that was successfully finished', function () {
 });
 
 it('finishes a process that failed', function () {
-    Config::setPath(__DIR__ . '/_testdata/config/ppq.php');
+    Config::setPath(helper_testConfigPath('ppq.php'));
 
     $queueRecord = new QueueRecord('default', TestJob::class, QueueJobStatus::running);
 

--- a/tests/ProcessesTest.php
+++ b/tests/ProcessesTest.php
@@ -4,7 +4,7 @@ use Otsch\Ppq\Processes;
 
 it('checks if a running process with a certain pid exists', function () {
     $process = \Symfony\Component\Process\Process::fromShellCommandline(
-        'php ' . __DIR__ . '/_testdata/scripts/do-something.php'
+        'php ' . helper_testScriptPath('do-something.php')
     );
 
     $process->start();
@@ -26,7 +26,7 @@ it('checks if a running process containing certain strings (in command) exists',
     expect(Processes::processContainingStringsExists(['counting.php']))->toBeFalse();
 
     $process = \Symfony\Component\Process\Process::fromShellCommandline(
-        'php ' . __DIR__ . '/_testdata/scripts/counting.php'
+        'php ' . helper_testScriptPath('counting.php')
     );
 
     $process->start();
@@ -36,7 +36,7 @@ it('checks if a running process containing certain strings (in command) exists',
 
 test('checking if a running process containing certain strings exists, exclude the current process', function () {
     $process = \Symfony\Component\Process\Process::fromShellCommandline(
-        'php ' . __DIR__ . '/_testdata/scripts/check-process-already-running.php'
+        'php ' . helper_testScriptPath('check-process-already-running.php')
     );
 
     $process->run();

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -10,7 +10,7 @@ use Otsch\Ppq\Utils;
 use Stubs\TestJob;
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 });

--- a/tests/SignalTest.php
+++ b/tests/SignalTest.php
@@ -4,10 +4,10 @@ use Otsch\Ppq\Config;
 use Otsch\Ppq\Signal;
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/_testdata/config/ppq.php');
+    Config::setPath(helper_testConfigPath('ppq.php'));
 
-    if (file_exists(__DIR__ . '/_testdata/datapath/signal')) {
-        file_put_contents(__DIR__ . '/_testdata/datapath/signal', '');
+    if (file_exists(helper_testDataPath('signal'))) {
+        file_put_contents(helper_testDataPath('signal'), '');
     }
 });
 

--- a/tests/Stubs/Listeners/DefaultCancelled.php
+++ b/tests/Stubs/Listeners/DefaultCancelled.php
@@ -2,13 +2,12 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class DefaultCancelled implements QueueEventListener
+class DefaultCancelled extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
-        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default cancelled called');
+        file_put_contents($this->dataPath('event-listeners-check-file'), 'default cancelled called');
     }
 }

--- a/tests/Stubs/Listeners/DefaultFailed.php
+++ b/tests/Stubs/Listeners/DefaultFailed.php
@@ -2,13 +2,12 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class DefaultFailed implements QueueEventListener
+class DefaultFailed extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
-        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default failed called');
+        file_put_contents($this->dataPath('event-listeners-check-file'), 'default failed called');
     }
 }

--- a/tests/Stubs/Listeners/DefaultFinished.php
+++ b/tests/Stubs/Listeners/DefaultFinished.php
@@ -2,13 +2,12 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class DefaultFinished implements QueueEventListener
+class DefaultFinished extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
-        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default finished called');
+        file_put_contents($this->dataPath('event-listeners-check-file'), 'default finished called');
     }
 }

--- a/tests/Stubs/Listeners/DefaultLost.php
+++ b/tests/Stubs/Listeners/DefaultLost.php
@@ -2,13 +2,12 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class DefaultLost implements QueueEventListener
+class DefaultLost extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
-        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default lost called');
+        file_put_contents($this->dataPath('event-listeners-check-file'), 'default lost called');
     }
 }

--- a/tests/Stubs/Listeners/DefaultRunning.php
+++ b/tests/Stubs/Listeners/DefaultRunning.php
@@ -2,13 +2,12 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class DefaultRunning implements QueueEventListener
+class DefaultRunning extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
-        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default running called');
+        file_put_contents($this->dataPath('event-listeners-check-file'), 'default running called');
     }
 }

--- a/tests/Stubs/Listeners/DefaultWaiting.php
+++ b/tests/Stubs/Listeners/DefaultWaiting.php
@@ -2,13 +2,12 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class DefaultWaiting implements QueueEventListener
+class DefaultWaiting extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
-        file_put_contents(__DIR__ . '/../../_testdata/datapath/event-listeners-check-file', 'default waiting called');
+        file_put_contents($this->dataPath('event-listeners-check-file'), 'default waiting called');
     }
 }

--- a/tests/Stubs/Listeners/OtherQueueFailedOne.php
+++ b/tests/Stubs/Listeners/OtherQueueFailedOne.php
@@ -2,17 +2,12 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class OtherQueueFailedOne implements QueueEventListener
+class OtherQueueFailedOne extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
-        file_put_contents(
-            __DIR__ . '/../../_testdata/datapath/event-listeners-check-file',
-            'other queue failed one called ',
-            FILE_APPEND,
-        );
+        file_put_contents($this->dataPath('event-listeners-check-file'), 'other queue failed one called ', FILE_APPEND);
     }
 }

--- a/tests/Stubs/Listeners/OtherQueueFailedThree.php
+++ b/tests/Stubs/Listeners/OtherQueueFailedThree.php
@@ -2,15 +2,14 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class OtherQueueFailedThree implements QueueEventListener
+class OtherQueueFailedThree extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
         file_put_contents(
-            __DIR__ . '/../../_testdata/datapath/event-listeners-check-file',
+            $this->dataPath('event-listeners-check-file'),
             'other queue failed three called',
             FILE_APPEND,
         );

--- a/tests/Stubs/Listeners/OtherQueueFailedTwo.php
+++ b/tests/Stubs/Listeners/OtherQueueFailedTwo.php
@@ -2,15 +2,14 @@
 
 namespace Stubs\Listeners;
 
-use Otsch\Ppq\Contracts\QueueEventListener;
 use Otsch\Ppq\Entities\QueueRecord;
 
-class OtherQueueFailedTwo implements QueueEventListener
+class OtherQueueFailedTwo extends TestQueueEventListener
 {
     public function invoke(QueueRecord $queueRecord): void
     {
         file_put_contents(
-            __DIR__ . '/../../_testdata/datapath/event-listeners-check-file',
+            $this->dataPath('event-listeners-check-file'),
             'other queue failed two called ',
             FILE_APPEND,
         );

--- a/tests/Stubs/Listeners/TestQueueEventListener.php
+++ b/tests/Stubs/Listeners/TestQueueEventListener.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Stubs\Listeners;
+
+use Otsch\Ppq\Contracts\QueueEventListener;
+
+abstract class TestQueueEventListener implements QueueEventListener
+{
+    protected function dataPath(string $withinPath = ''): string
+    {
+        if (!empty($withinPath)) {
+            $withinPath = str_starts_with($withinPath, '/') ? $withinPath : '/' . $withinPath;
+        }
+
+        return __DIR__ . '/../../_testdata/datapath' . $withinPath;
+    }
+}

--- a/tests/WorkerProcessTest.php
+++ b/tests/WorkerProcessTest.php
@@ -5,7 +5,7 @@ use Otsch\Ppq\Ppq;
 use Otsch\Ppq\WorkerProcess;
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     if (file_exists(Ppq::dataPath('workerprocess'))) {
         unlink(Ppq::dataPath('workerprocess'));

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -10,13 +10,13 @@ use Otsch\Ppq\Utils;
 use Stubs\TestJob;
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 });
 
 beforeAll(function () {
-    Config::setPath(__DIR__ . '/_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     WorkerProcess::work();
 });

--- a/tests/_integration/CancelJobTest.php
+++ b/tests/_integration/CancelJobTest.php
@@ -13,11 +13,11 @@ use Otsch\Ppq\Utils;
 use Stubs\TestJob;
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 });
 
 beforeAll(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 

--- a/tests/_integration/ClearQueueTest.php
+++ b/tests/_integration/ClearQueueTest.php
@@ -9,13 +9,13 @@ use Otsch\Ppq\Ppq;
 use Stubs\TestJob;
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 });
 
 beforeAll(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 

--- a/tests/_integration/FlushQueueTest.php
+++ b/tests/_integration/FlushQueueTest.php
@@ -10,13 +10,13 @@ use Otsch\Ppq\Ppq;
 use Stubs\TestJob;
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 });
 
 beforeAll(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 

--- a/tests/_integration/JobLogTest.php
+++ b/tests/_integration/JobLogTest.php
@@ -15,11 +15,11 @@ use Stubs\LogLinesTestJob;
 use Stubs\LogTestJob;
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 });
 
 beforeAll(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     helper_cleanUpDataPathQueueFiles();
 

--- a/tests/_integration/QueueEventListenersTest.php
+++ b/tests/_integration/QueueEventListenersTest.php
@@ -14,12 +14,12 @@ use Stubs\TestJobPhpError;
 use Stubs\TestJobThrowingException;
 
 beforeAll(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/event-listeners.php');
+    Config::setPath(helper_testConfigPath('event-listeners.php'));
 
-    if (!file_exists(__DIR__ . '/../_testdata/datapath/event-listeners-check-file')) {
-        touch(__DIR__ . '/../_testdata/datapath/event-listeners-check-file');
+    if (!file_exists(helper_testDataPath('event-listeners-check-file'))) {
+        touch(helper_testDataPath('event-listeners-check-file'));
     } else {
-        file_put_contents(__DIR__ . '/../_testdata/datapath/event-listeners-check-file', '');
+        file_put_contents(helper_testDataPath('event-listeners-check-file'), '');
     }
 
     helper_cleanUpDataPathQueueFiles();
@@ -28,9 +28,9 @@ beforeAll(function () {
 });
 
 beforeEach(function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/event-listeners.php');
+    Config::setPath(helper_testConfigPath('event-listeners.php'));
 
-    file_put_contents(__DIR__ . '/../_testdata/datapath/event-listeners-check-file', '');
+    file_put_contents(helper_testDataPath('event-listeners-check-file'), '');
 });
 
 afterAll(function () {
@@ -41,7 +41,7 @@ afterAll(function () {
 
 function helper_getListenerCheckFileContent(): string
 {
-    $fileContent = file_get_contents(__DIR__ . '/../_testdata/datapath/event-listeners-check-file');
+    $fileContent = file_get_contents(helper_testDataPath('event-listeners-check-file'));
 
     if ($fileContent === false) {
         return '';

--- a/tests/_integration/WorkCommandTest.php
+++ b/tests/_integration/WorkCommandTest.php
@@ -6,7 +6,7 @@ use Otsch\Ppq\Kernel;
 use Otsch\Ppq\Utils;
 
 it('does not start a second worker process', function () {
-    Config::setPath(__DIR__ . '/../_testdata/config/filesystem-ppq.php');
+    Config::setPath(helper_testConfigPath('filesystem-ppq.php'));
 
     WorkerProcess::work();
 


### PR DESCRIPTION
When the new content of the ppq index file was shorter than the old content, it wrote the new content starting from the beginning of the file and the part of the old content that was longer than the new content, remained at the end of the file. Fixed it be truncating the file before writing the new content.