### PR TITLE
Error handling

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,6 +4,7 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()
+    ->notPath(['tests/Stubs/PhpParseErrorJob.php'])
     ->exclude(['.github', 'bin', 'git-hooks'])
     ->in(__DIR__);
 $config = new Config();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-08-03
+### Added
+* Error handling functionality. You can now add a `error_handler` in your config, like this: `['error_handler' => ['class' => MyErrorHandler::class, 'active' => true]`. The class needs to extend the new abstract class `Otsch\Ppq\AbstractErrorHandler`. In its `boot()` method you can register one or multiple error handlers via its own `registerHandler()` method. The handlers are automatically called with any uncaught exception or PHP warnings and errors (turned into `ErrorException`s) occuring during a PPQ job execution.
+
 ## [0.1.2] - 2022-07-13
 ### Fixed
 * Fix identifying Sub-Processes that need to be killed, when cancelling a running Process.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ return [
          */
         'active' => true,
     ],
+    
+    /**
+     * Optional. If you cannot reliably control the error_reporting() level for the sub-process
+     * in which the background job is executed, define a level here. It will be passed
+     * as a parameter when starting the process.
+     */
+    'error_reporting' => 'E_ALL',
 ];
 ```
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,7 @@ parameters:
     paths:
         - src
         - tests
+    excludePaths:
+        - tests/Stubs/PhpParseErrorJob.php
     ignoreErrors:
         - "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:\\S+\\(\\)\\.$#"

--- a/src/AbstractErrorHandler.php
+++ b/src/AbstractErrorHandler.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Otsch\Ppq;
+
+use Closure;
+use ErrorException;
+use Throwable;
+
+abstract class AbstractErrorHandler
+{
+    /**
+     * @var Closure[]
+     */
+    protected array $handlers = [];
+
+    private bool $active = true;
+
+    /**
+     * @var callable|null
+     */
+    private mixed $initialHandlers = null;
+
+    public function __construct()
+    {
+        $this->boot();
+    }
+
+    abstract public function boot(): void;
+
+    public function handleException(Throwable $exception): void
+    {
+        if ($this->active) {
+            foreach ($this->handlers as $handler) {
+                $handler($exception);
+            }
+        }
+    }
+
+    public function deactivate(): void
+    {
+        $this->active = false;
+
+        if (!empty($this->handlers) && !empty($this->initialHandlers)) {
+            set_error_handler($this->initialHandlers);
+        }
+    }
+
+    protected function registerHandler(Closure $handler, bool $ignoreWarnings = false): static
+    {
+        $firstHandler = empty($this->handlers);
+
+        $this->handlers[] = $handler;
+
+        $initialHandlers = set_error_handler(
+            function (
+                int $errno,
+                string $errstr,
+                string $errfile,
+                int $errline,
+            ) use ($handler) {
+                $handler(new ErrorException($errstr, 0, $errno, $errfile, $errline));
+
+                return false;
+            },
+            $ignoreWarnings ? E_ALL & ~E_WARNING & ~E_NOTICE : E_ALL & ~E_NOTICE,
+        );
+
+        if ($firstHandler) {
+            $this->initialHandlers = $initialHandlers;
+
+            register_shutdown_function(function () use ($handler) {
+                if ($this->active) {
+                    $error = error_get_last();
+
+                    if ($error && in_array($error['type'], [E_ERROR, E_PARSE], true)) {
+                        $handler(new ErrorException($error['message'], 0, $error['type'], $error['file'], $error['line']));
+                    }
+                }
+            });
+        }
+
+        return $this;
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -110,7 +110,7 @@ class Kernel
     {
         $job = $this->getJobByIdOrFail();
 
-        /** @var QueueRecord $job */
+        $errorHandler = $this->getErrorHandler();
 
         try {
             $job = new $job->jobClass(...$job->args);
@@ -123,15 +123,21 @@ class Kernel
 
             $job->invoke();
         } catch (Exception $exception) {
-            $this->fail->withMessage($exception->getMessage());
+            $errorHandler?->handleException($exception);
+
+            $this->fail->withMessage(
+                'Uncaught ' . get_class($exception) . ': ' . $exception->getMessage() . PHP_EOL . ' in ' .
+                $exception->getFile() . ' on line ' . $exception->getLine()
+            );
         }
     }
 
+    /**
+     * @throws Exception
+     */
     protected function cancelJob(): void
     {
         $job = $this->getJobByIdOrFail();
-
-        /** @var QueueRecord $job */
 
         Ppq::cancel($job->id);
     }
@@ -202,12 +208,13 @@ class Kernel
         $this->logger->info('Flushed all queues');
     }
 
+    /**
+     * @throws Exception
+     */
     protected function showLog(): void
     {
         if ($this->argv->jobId()) {
             $job = $this->getJobByIdOrFail();
-
-            /** @var QueueRecord $job */
 
             $numberOfLines = $this->argv->lines();
 
@@ -223,7 +230,34 @@ class Kernel
         }
     }
 
-    protected function getJobByIdOrFail(): ?QueueRecord
+    /**
+     * @throws Exception
+     */
+    protected function getErrorHandler(): ?AbstractErrorHandler
+    {
+        $mainErrorHandler = Config::get('error_handler');
+
+        if (
+            isset($mainErrorHandler['class']) &&
+            isset($mainErrorHandler['active']) &&
+            $mainErrorHandler['active'] === true
+        ) {
+            $handler = new $mainErrorHandler['class']();
+
+            if (!$handler instanceof AbstractErrorHandler) {
+                throw new Exception('Configured error_handler class doesn\'t extend the AbstractErrorHandler class.');
+            }
+
+            return $handler;
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function getJobByIdOrFail(): QueueRecord
     {
         if (!$this->argv->jobId()) {
             throw new Exception('No or invalid job id.');
@@ -233,6 +267,8 @@ class Kernel
 
         if ($job === null) {
             $this->fail->withMessage('Job with id ' . $this->argv->jobId() . ' not found');
+
+            throw new Exception('This exception should only be possible in the unit tests when mocking $this->fail');
         }
 
         return $job;

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -31,13 +31,18 @@ class Kernel
         $this->logger = new EchoLogger();
     }
 
-    public static function ppqCommand(string $command, ?string $logPath = null): SymfonyProcess
-    {
+    public static function ppqCommand(
+        string $command,
+        ?string $logPath = null,
+        ?string $iniConfigOption = null,
+    ): SymfonyProcess {
         if ($logPath) {
             touch($logPath);
         }
 
-        $command = 'php ' . self::ppqPath() . ' ' . $command . ' --config=' . Config::getPath();
+        $iniConfigOption = $iniConfigOption ? '-d ' . $iniConfigOption . ' ' : '';
+
+        $command = 'php ' . $iniConfigOption . self::ppqPath() . ' ' . $command . ' --config=' . Config::getPath();
 
         if ($logPath) {
             $command .= ' >> ' . $logPath . ' 2>&1';

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -116,6 +116,14 @@ class Queue
     }
 
     /**
+     * @return Process[]
+     */
+    public function getProcesses(): array
+    {
+        return $this->processes;
+    }
+
+    /**
      * @return QueueRecord[]
      * @throws InvalidQueueDriverException
      */

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -50,7 +50,11 @@ class Queue
      */
     public function startWaitingJob(QueueRecord $waitingJob): void
     {
-        $process = Kernel::ppqCommand('run ' . $waitingJob->id, Logs::queueJobLogPath($waitingJob));
+        $process = Kernel::ppqCommand(
+            'run ' . $waitingJob->id,
+            Logs::queueJobLogPath($waitingJob),
+            Config::get('error_reporting') ? 'error_reporting=' . Config::get('error_reporting') : '',
+        );
 
         $process->start();
 

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Otsch\Ppq\AbstractErrorHandler;
+
+it('calls all registered handlers with uncaught exceptions', function () {
+    $handler = new class () extends AbstractErrorHandler {
+        /**
+         * @var Throwable[]
+         */
+        public array $_exceptions = [];
+
+        /**
+         * @var Throwable[]
+         */
+        public array $_exceptions2 = [];
+
+        public function boot(): void
+        {
+            $this->registerHandler(function (Throwable $exception) {
+                $this->_exceptions[] = $exception;
+            });
+
+            $this->registerHandler(function (Throwable $exception) {
+                $this->_exceptions2[] = $exception;
+            });
+        }
+    };
+
+    $exception = new InvalidArgumentException('test test');
+
+    $handler->handleException($exception);
+
+    expect($handler->_exceptions[0])->toBe($exception)
+        ->and($handler->_exceptions2[0])->toBe($exception);
+
+    $handler->deactivate(); // So it does not influence other tests running in the same process.
+});

--- a/tests/KernelTest.php
+++ b/tests/KernelTest.php
@@ -83,13 +83,19 @@ it('throws an Exception when there is no job ID in the argv arguments', function
 it('fails when the job ID to run is not on the queue', function () {
     $failMock = Mockery::mock(Fail::class);
 
-    $failMock->shouldReceive('withMessage')->twice(); // @phpstan-ignore-line
+    $failMock->shouldReceive('withMessage')->once(); // @phpstan-ignore-line
 
     $queueJob = new QueueRecord('default', TestJob::class);
 
     $kernel = new Kernel(['vendor/bin/ppq', 'run', $queueJob->id], fail: $failMock); // @phpstan-ignore-line
 
-    $kernel->run();
+    try {
+        $kernel->run();
+    } catch (Exception $exception) {
+        expect($exception->getMessage())->toBe(
+            'This exception should only be possible in the unit tests when mocking $this->fail',
+        );
+    }
 });
 
 it('fails when the job class to run does not implement the QueueableJob interface', function () {

--- a/tests/KernelTest.php
+++ b/tests/KernelTest.php
@@ -38,6 +38,16 @@ it('appends the set config path as --c option to the ppq command', function () {
     expect($process->getCommandLine())->toEndWith('--config=' . Config::getPath());
 });
 
+it(
+    'adds the -d option with the provided ini setting, when the $iniConfigOption parameter of the ppqCommand() ' .
+    'method is used',
+    function () {
+        $process = Kernel::ppqCommand('run 123', iniConfigOption: 'error_reporting=E_ALL');
+
+        expect($process->getCommandLine())->toStartWith('php -d error_reporting=E_ALL ');
+    }
+);
+
 it('calls the bootstrap file defined in the config when run() is called', function () {
     $kernel = new Kernel([]);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -130,4 +130,27 @@ function helper_containsInOneLine(string $string, array $contains): bool
     }
 
     return false;
-};
+}
+
+function helper_emptyHandlerEventsFile(): void
+{
+    $handlerEventsFile = helper_testDataPath('error-handler-events');
+
+    if (!file_exists($handlerEventsFile)) {
+        touch($handlerEventsFile);
+    } else {
+        file_put_contents($handlerEventsFile, '');
+    }
+}
+
+function helper_dump(mixed $var): void
+{
+    error_log(var_export($var, true));
+}
+
+function helper_dieDump(mixed $var): void
+{
+    error_log(var_export($var, true));
+
+    exit;
+}

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -37,6 +37,16 @@ it('starts a waiting job', function () {
 
     expect($job->pid)->toBeInt()->toBeGreaterThan(0);
 
+    $processes = $queue->getProcesses();
+
+    $latestProcess = end($processes);
+
+    if (!$latestProcess) {
+        throw new Exception('No latest process in queue');
+    }
+
+    expect($latestProcess->process->getCommandLine())->toContain('-d error_reporting=E_ALL');
+
     $pid = $job->pid;
 
     /** @var int $pid */

--- a/tests/Stubs/AbstractTestErrorHandler.php
+++ b/tests/Stubs/AbstractTestErrorHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Stubs;
+
+use ErrorException;
+use Otsch\Ppq\AbstractErrorHandler;
+use Throwable;
+
+abstract class AbstractTestErrorHandler extends AbstractErrorHandler
+{
+    protected function logErrorEvent(Throwable $exception): void
+    {
+        if ($exception instanceof ErrorException) {
+            if ($exception->getSeverity() === E_WARNING) {
+                $message = 'PHP Warning: ' . $exception->getMessage();
+            } elseif ($exception->getSeverity() === E_ERROR) {
+                $message = 'PHP Error: ' . $exception->getMessage();
+            } elseif ($exception->getSeverity() === E_PARSE) {
+                $message = 'PHP Parse Error: ' . $exception->getMessage();
+            } else {
+                $message = 'PHP Error (Severity ' . $exception->getSeverity() . '): ' . $exception->getMessage();
+            }
+        } else {
+            $message = get_class($exception) . ': ' . $exception->getMessage();
+        }
+
+        file_put_contents(
+            __DIR__ . '/../_testdata/datapath/error-handler-events',
+            $message . PHP_EOL,
+            FILE_APPEND,
+        );
+    }
+}

--- a/tests/Stubs/ErrorHandler.php
+++ b/tests/Stubs/ErrorHandler.php
@@ -8,6 +8,12 @@ class ErrorHandler extends AbstractTestErrorHandler
 {
     public function boot(): void
     {
+        file_put_contents(
+            __DIR__ . '/../_testdata/datapath/error-handler-events',
+            'error reporting: ' . error_reporting(),
+            FILE_APPEND,
+        );
+
         $this->registerHandler(function (Throwable $exception) {
             $this->logErrorEvent($exception);
         });

--- a/tests/Stubs/ErrorHandler.php
+++ b/tests/Stubs/ErrorHandler.php
@@ -8,12 +8,6 @@ class ErrorHandler extends AbstractTestErrorHandler
 {
     public function boot(): void
     {
-        file_put_contents(
-            __DIR__ . '/../_testdata/datapath/error-handler-events',
-            'error reporting: ' . error_reporting(),
-            FILE_APPEND,
-        );
-
         $this->registerHandler(function (Throwable $exception) {
             $this->logErrorEvent($exception);
         });

--- a/tests/Stubs/ErrorHandler.php
+++ b/tests/Stubs/ErrorHandler.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Stubs;
+
+use Throwable;
+
+class ErrorHandler extends AbstractTestErrorHandler
+{
+    public function boot(): void
+    {
+        $this->registerHandler(function (Throwable $exception) {
+            $this->logErrorEvent($exception);
+        });
+    }
+}

--- a/tests/Stubs/ErrorHandlerIgnoreWarnings.php
+++ b/tests/Stubs/ErrorHandlerIgnoreWarnings.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Stubs;
+
+use Throwable;
+
+class ErrorHandlerIgnoreWarnings extends AbstractTestErrorHandler
+{
+    public function boot(): void
+    {
+        $this->registerHandler(function (Throwable $exception) {
+            $this->logErrorEvent($exception);
+        }, true); // Set second parameter "ignoreWarnings" to true.
+    }
+}

--- a/tests/Stubs/ExceptionJob.php
+++ b/tests/Stubs/ExceptionJob.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Stubs;
+
+use Exception;
+use Otsch\Ppq\PpqJob;
+
+class ExceptionJob extends PpqJob
+{
+    /**
+     * @throws Exception
+     */
+    public function invoke(): void
+    {
+        throw new Exception('This is an uncaught test exception');
+    }
+}

--- a/tests/Stubs/PhpErrorJob.php
+++ b/tests/Stubs/PhpErrorJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Stubs;
+
+use Otsch\Ppq\PpqJob;
+
+class PhpErrorJob extends PpqJob
+{
+    /**
+     * Job to cause a PHP error, for testing error handlers.
+     */
+    public function invoke(): void
+    {
+        $this->nonExistingFunction(); // @phpstan-ignore-line
+    }
+}

--- a/tests/Stubs/PhpParseErrorJob.php
+++ b/tests/Stubs/PhpParseErrorJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Stubs;
+
+use Otsch\Ppq\PpqJob;
+
+class PhpParseErrorJob extends PpqJob
+{
+    /**
+     * Job to cause a PHP parse error, for testing error handlers.
+     */
+    public function invoke(): void
+    {
+        syntax error
+    }
+}

--- a/tests/Stubs/PhpWarningJob.php
+++ b/tests/Stubs/PhpWarningJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Stubs;
+
+use Otsch\Ppq\PpqJob;
+
+class PhpWarningJob extends PpqJob
+{
+    /**
+     * Job to cause a PHP warning, for testing error handlers.
+     */
+    public function invoke(): void
+    {
+        unserialize('foo');
+    }
+}

--- a/tests/Stubs/PhpWarningJob.php
+++ b/tests/Stubs/PhpWarningJob.php
@@ -11,6 +11,6 @@ class PhpWarningJob extends PpqJob
      */
     public function invoke(): void
     {
-        unserialize('foo');
+        $content = file_get_contents(__DIR__ . '/file-that-does-not-exist');
     }
 }

--- a/tests/_integration/ErrorHandlerIgnoreWarningsTest.php
+++ b/tests/_integration/ErrorHandlerIgnoreWarningsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Integration;
+
+use Otsch\Ppq\Config;
+use Otsch\Ppq\Dispatcher;
+use Otsch\Ppq\Entities\Values\QueueJobStatus;
+use Otsch\Ppq\Ppq;
+use Otsch\Ppq\Utils;
+use Stubs\PhpWarningJob;
+
+beforeAll(function () {
+    Config::setPath(helper_testConfigPath('error-handler-ignore-warnings.php'));
+
+    WorkerProcess::work();
+
+    helper_cleanUpDataPathQueueFiles();
+});
+
+beforeEach(function () {
+    // Worker should already be running, but if it somehow died, it will be restarted.
+    Config::setPath(helper_testConfigPath('error-handler-ignore-warnings.php'));
+
+    WorkerProcess::work();
+
+    helper_emptyHandlerEventsFile();
+});
+
+afterAll(function () {
+    WorkerProcess::stop();
+
+    helper_cleanUpDataPathQueueFiles();
+
+    helper_emptyHandlerEventsFile();
+});
+
+it('ignores warnings when parameter used in registerHandler()', function () {
+    // See Stubs/ErrorHandlerIgnoreWarnings.php
+    Config::setPath(helper_testConfigPath('error-handler-ignore-warnings.php'));
+
+    $job = Dispatcher::queue('default')
+        ->job(PhpWarningJob::class)
+        ->dispatch();
+
+    Utils::tryUntil(function () use ($job) {
+        return Ppq::find($job->id)?->status === QueueJobStatus::finished;
+    });
+
+    $job = Ppq::find($job->id);
+
+    $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
+
+    expect($job?->status)->toBe(QueueJobStatus::finished)
+        ->and($handlerEvents)->not->toContain('PHP Warning: unserialize(): Error at offset 0 of 3 bytes');
+});

--- a/tests/_integration/ErrorHandlerTest.php
+++ b/tests/_integration/ErrorHandlerTest.php
@@ -60,7 +60,7 @@ it('handles a PHP warning', function () {
         ->dispatch();
 
     Utils::tryUntil(function () use ($job) {
-        return Ppq::find($job->id)?->status === QueueJobStatus::failed;
+        return Ppq::find($job->id)?->status === QueueJobStatus::finished;
     });
 
     $job = Ppq::find($job->id);

--- a/tests/_integration/ErrorHandlerTest.php
+++ b/tests/_integration/ErrorHandlerTest.php
@@ -67,9 +67,11 @@ it('handles a PHP warning', function () {
 
     $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
 
+    helper_dump(file_exists(helper_testDataPath('error-handler-events')));
+
     expect($job?->status)->toBe(QueueJobStatus::finished)
         ->and($handlerEvents)->toContain('PHP Warning: unserialize(): Error at offset 0 of 3 bytes');
-});
+})->only();
 
 it('handles a PHP error', function () {
     $job = Dispatcher::queue('default')

--- a/tests/_integration/ErrorHandlerTest.php
+++ b/tests/_integration/ErrorHandlerTest.php
@@ -5,6 +5,7 @@ namespace Integration;
 use Otsch\Ppq\Config;
 use Otsch\Ppq\Dispatcher;
 use Otsch\Ppq\Entities\Values\QueueJobStatus;
+use Otsch\Ppq\Logs;
 use Otsch\Ppq\Ppq;
 use Otsch\Ppq\Utils;
 use Stubs\ExceptionJob;
@@ -55,8 +56,6 @@ it('handles an uncaught exception', function () {
 });
 
 it('handles a PHP warning', function () {
-    error_reporting(E_ALL);
-
     $job = Dispatcher::queue('default')
         ->job(PhpWarningJob::class)
         ->dispatch();
@@ -69,9 +68,9 @@ it('handles a PHP warning', function () {
 
     $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
 
-    helper_dump(file_exists(helper_testDataPath('error-handler-events')));
-    helper_dump(error_reporting());
     helper_dump($handlerEvents);
+
+    helper_dump(Logs::getJobLog($job)); // @phpstan-ignore-line
 
     expect($job?->status)->toBe(QueueJobStatus::finished)
         ->and($handlerEvents)->toContain('PHP Warning: unserialize(): Error at offset 0 of 3 bytes');

--- a/tests/_integration/ErrorHandlerTest.php
+++ b/tests/_integration/ErrorHandlerTest.php
@@ -55,6 +55,8 @@ it('handles an uncaught exception', function () {
 });
 
 it('handles a PHP warning', function () {
+    error_reporting(E_ALL);
+
     $job = Dispatcher::queue('default')
         ->job(PhpWarningJob::class)
         ->dispatch();
@@ -68,6 +70,8 @@ it('handles a PHP warning', function () {
     $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
 
     helper_dump(file_exists(helper_testDataPath('error-handler-events')));
+    helper_dump(error_reporting());
+    helper_dump($handlerEvents);
 
     expect($job?->status)->toBe(QueueJobStatus::finished)
         ->and($handlerEvents)->toContain('PHP Warning: unserialize(): Error at offset 0 of 3 bytes');

--- a/tests/_integration/ErrorHandlerTest.php
+++ b/tests/_integration/ErrorHandlerTest.php
@@ -68,13 +68,10 @@ it('handles a PHP warning', function () {
 
     $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
 
-    helper_dump($handlerEvents);
-
-    helper_dump(Logs::getJobLog($job)); // @phpstan-ignore-line
-
     expect($job?->status)->toBe(QueueJobStatus::finished)
-        ->and($handlerEvents)->toContain('PHP Warning: unserialize(): Error at offset 0 of 3 bytes');
-})->only();
+        ->and($handlerEvents)->toContain('PHP Warning: file_get_contents(')
+        ->and($handlerEvents)->toContain('Failed to open stream: No such file or directory');
+});
 
 it('handles a PHP error', function () {
     $job = Dispatcher::queue('default')

--- a/tests/_integration/ErrorHandlerTest.php
+++ b/tests/_integration/ErrorHandlerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Integration;
+
+use Otsch\Ppq\Config;
+use Otsch\Ppq\Dispatcher;
+use Otsch\Ppq\Entities\Values\QueueJobStatus;
+use Otsch\Ppq\Ppq;
+use Otsch\Ppq\Utils;
+use Stubs\ExceptionJob;
+use Stubs\PhpErrorJob;
+use Stubs\PhpParseErrorJob;
+use Stubs\PhpWarningJob;
+
+beforeAll(function () {
+    Config::setPath(helper_testConfigPath('error-handlers.php'));
+
+    WorkerProcess::work();
+
+    helper_cleanUpDataPathQueueFiles();
+});
+
+beforeEach(function () {
+    // Worker should already be running, but if it somehow died, it will be restarted.
+    Config::setPath(helper_testConfigPath('error-handlers.php'));
+
+    WorkerProcess::work();
+
+    helper_emptyHandlerEventsFile();
+});
+
+afterAll(function () {
+    WorkerProcess::stop();
+
+    helper_cleanUpDataPathQueueFiles();
+
+    helper_emptyHandlerEventsFile();
+});
+
+it('handles an uncaught exception', function () {
+    $job = Dispatcher::queue('default')
+        ->job(ExceptionJob::class)
+        ->dispatch();
+
+    Utils::tryUntil(function () use ($job) {
+        return Ppq::find($job->id)?->status === QueueJobStatus::failed;
+    });
+
+    $job = Ppq::find($job->id);
+
+    $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
+
+    expect($job?->status)->toBe(QueueJobStatus::failed)
+        ->and($handlerEvents)->toContain('Exception: This is an uncaught test exception');
+});
+
+it('handles a PHP warning', function () {
+    $job = Dispatcher::queue('default')
+        ->job(PhpWarningJob::class)
+        ->dispatch();
+
+    Utils::tryUntil(function () use ($job) {
+        return Ppq::find($job->id)?->status === QueueJobStatus::failed;
+    });
+
+    $job = Ppq::find($job->id);
+
+    $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
+
+    expect($job?->status)->toBe(QueueJobStatus::finished)
+        ->and($handlerEvents)->toContain('PHP Warning: unserialize(): Error at offset 0 of 3 bytes');
+});
+
+it('handles a PHP error', function () {
+    $job = Dispatcher::queue('default')
+        ->job(PhpErrorJob::class)
+        ->dispatch();
+
+    Utils::tryUntil(function () use ($job) {
+        return Ppq::find($job->id)?->status === QueueJobStatus::failed;
+    });
+
+    $job = Ppq::find($job->id);
+
+    $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
+
+    expect($job?->status)->toBe(QueueJobStatus::failed)
+        ->and($handlerEvents)->toContain('PHP Error: Uncaught Error: Call to undefined method');
+});
+
+it('handles a PHP parse error', function () {
+    $job = Dispatcher::queue('default')
+        ->job(PhpParseErrorJob::class) // @phpstan-ignore-line
+        ->dispatch();
+
+    Utils::tryUntil(function () use ($job) {
+        return Ppq::find($job->id)?->status === QueueJobStatus::failed;
+    });
+
+    $job = Ppq::find($job->id);
+
+    $handlerEvents = file_get_contents(helper_testDataPath('error-handler-events'));
+
+    expect($job?->status)->toBe(QueueJobStatus::failed)
+        ->and($handlerEvents)->toContain('PHP Parse Error: syntax error, unexpected identifier "error"');
+});

--- a/tests/_testdata/config/error-handler-ignore-warnings.php
+++ b/tests/_testdata/config/error-handler-ignore-warnings.php
@@ -1,0 +1,18 @@
+<?php
+
+use Stubs\ErrorHandlerIgnoreWarnings;
+
+return [
+    'datapath' => __DIR__ . '/../datapath',
+
+    'queues' => [
+        'default' => [
+            'concurrent_jobs' => 2,
+        ],
+    ],
+
+    'error_handler' => [
+        'class' => ErrorHandlerIgnoreWarnings::class,
+        'active' => true,
+    ],
+];

--- a/tests/_testdata/config/error-handler-ignore-warnings.php
+++ b/tests/_testdata/config/error-handler-ignore-warnings.php
@@ -11,6 +11,8 @@ return [
         ],
     ],
 
+    'error_reporting' => E_ALL,
+
     'error_handler' => [
         'class' => ErrorHandlerIgnoreWarnings::class,
         'active' => true,

--- a/tests/_testdata/config/error-handlers.php
+++ b/tests/_testdata/config/error-handlers.php
@@ -1,0 +1,18 @@
+<?php
+
+use Stubs\ErrorHandler;
+
+return [
+    'datapath' => __DIR__ . '/../datapath',
+
+    'queues' => [
+        'default' => [
+            'concurrent_jobs' => 2,
+        ],
+    ],
+
+    'error_handler' => [
+        'class' => ErrorHandler::class,
+        'active' => true,
+    ],
+];

--- a/tests/_testdata/config/error-handlers.php
+++ b/tests/_testdata/config/error-handlers.php
@@ -11,6 +11,8 @@ return [
         ],
     ],
 
+    'error_reporting' => 'E_ALL',
+
     'error_handler' => [
         'class' => ErrorHandler::class,
         'active' => true,

--- a/tests/_testdata/config/filesystem-ppq.php
+++ b/tests/_testdata/config/filesystem-ppq.php
@@ -22,4 +22,6 @@ return [
             'concurrent_jobs' => 0,
         ],
     ],
+
+    'error_reporting' => 'E_ALL',
 ];


### PR DESCRIPTION
An error handler can now be added via the config. The error handler class must extend the new `AbstractErrorHandler` class, implement a method `boot()` where a user registers one or multiple error handlers. The handlers are automatically called with any uncaught exception or PHP warnings and errors (turned into `ErrorException`s) occuring during a PPQ job execution.